### PR TITLE
State machine fixes

### DIFF
--- a/master/sip_master/configure.py
+++ b/master/sip_master/configure.py
@@ -22,10 +22,11 @@ class Configure(threading.Thread):
         log.info('Starting configuration.')
 
         # Go through the slave map and start all the tasks that are marked
-        # as being required for the system to be online
+        # as being required for the system to be online. For these tasks
+        # we use the same string for both the task name and type as, by
+        # definition there is only one task of each type.
         for task, cfg in config.slave_config.items():
             if cfg.get('online', False):
-                # FIXME(BM) should this be task, name?
                 slave_control.start(task, task)
 
         log.info('Configuration thread exiting.')

--- a/master/sip_master/heartbeat_listener.py
+++ b/master/sip_master/heartbeat_listener.py
@@ -141,7 +141,7 @@ class HeartbeatListener(threading.Thread):
         # Post an event to the MC state machine
         if tasks_running == 0:
             config.state_machine.post_event(['no tasks'])
-        elif services_running == number_of_services:
+        if services_running == number_of_services:
             config.state_machine.post_event(['all services'])
-        else:
+        elif services_running > 0:
             config.state_machine.post_event(['some services'])

--- a/master/sip_master/heartbeat_listener.py
+++ b/master/sip_master/heartbeat_listener.py
@@ -47,6 +47,7 @@ class HeartbeatListener(threading.Thread):
         are no messages to retrieve.
         """
         self._listener = heartbeat.Listener(0)
+        self._sm = sm
         super(HeartbeatListener, self).__init__(daemon = True)
 
     def connect(self, host, port):
@@ -140,8 +141,8 @@ class HeartbeatListener(threading.Thread):
 
         # Post an event to the MC state machine
         if tasks_running == 0:
-            config.state_machine.post_event(['no tasks'])
+            self._sm.post_event(['no tasks'])
         if services_running == number_of_services:
-            config.state_machine.post_event(['all services'])
+            self._sm.post_event(['all services'])
         elif services_running > 0:
-            config.state_machine.post_event(['some services'])
+            self._sm.post_event(['some services'])

--- a/master/sip_master/heartbeat_listener.py
+++ b/master/sip_master/heartbeat_listener.py
@@ -94,8 +94,9 @@ class HeartbeatListener(threading.Thread):
                 if state == 'busy':
                     status['state'].post_event(['busy heartbeat'])
                 elif state == 'idle':
-                    log.info('idle heartbeat from {}'.format(name))
                     status['state'].post_event(['idle heartbeat'])
+                elif state == 'error':
+                    status['state'].post_event(['error heartbeat'])
                 else:
                     log.error('Invalid state received from slave: {}'.
                               format(state))

--- a/master/sip_master/master_states.py
+++ b/master/sip_master/master_states.py
@@ -84,7 +84,6 @@ class MasterControllerSM(StateMachine):
 
     state_table = {
         'Standby': {
-            'all services':     (1, Available, None),
             'offline':          (0, None, None),
             'online':           (1, Configuring, online),
             'shutdown':         (1, _End, shutdown)
@@ -96,7 +95,6 @@ class MasterControllerSM(StateMachine):
             'shutdown':         (0, None, None)
         },
         'Available': {
-            'no tasks':         (1, Standby, None),
             'some services':    (1, Unavailable, None),
             'offline':          (1, UnConfiguring, offline),
             'online':           (0, None, None),
@@ -105,7 +103,6 @@ class MasterControllerSM(StateMachine):
             'degrade':          (1, Degraded, None)
         },
         'Degraded': {
-            'no tasks':         (1, Standby, None),
             'some services':    (1, Unavailable, None),
             'all services':     (1, Available, None),
             'offline':          (1, UnConfiguring, offline),
@@ -113,7 +110,6 @@ class MasterControllerSM(StateMachine):
             'shutdown':         (0, None, None)
         },
         'Unavailable': {
-            'no tasks':         (1, Standby, None),
             'all services':     (1, Available, None),
             'offline':          (1, UnConfiguring, offline),
             'online':           (0, None, None),

--- a/master/sip_master/slave_states.py
+++ b/master/sip_master/slave_states.py
@@ -48,6 +48,12 @@ class Missing(State):
         log.info('{} (type {}) state timed-out'.format(sm._name, sm._type))
 
 
+class Error(State):
+    """Slave error state."""
+    def __init__(self, sm):
+        log.info('{} (type {}) state error'.format(sm._name, sm._type))
+
+
 class SlaveControllerSM(StateMachine):
     """Slave Controller state machine class."""
     def __init__(self, name, type, task_controller):
@@ -68,6 +74,7 @@ class SlaveControllerSM(StateMachine):
         'Starting': {
             'idle heartbeat':   (1, Idle, LoadTask),
             'busy heartbeat':   (1, Busy, None),
+            'error heartbeat':  (1, Error, None),
             'stop sent':        (1, _End, None)
         },
         'Idle': {
@@ -80,14 +87,21 @@ class SlaveControllerSM(StateMachine):
             'busy heartbeat':   (1, Busy, None),
             'idle heartbeat':   (1, Idle, None),
             'no heartbeat':     (1, Missing, None),
+            'error heartbeat':  (1, Error, None),
             'stop sent':        (1, _End, None)
         },
         'Busy': {
             'idle heartbeat':   (1, Idle, None),
             'no heartbeat':     (1, Missing, None),
+            'error heartbeat':  (1, Error, None),
             'stop sent':        (1, _End, None)
         },
         'Missing': {
+            'idle heartbeat':   (1, Idle, LoadTask),
+            'busy heartbeat':   (1, Busy, None),
+            'stop sent':        (1, _End, None)
+        },
+        'Error': {
             'idle heartbeat':   (1, Idle, LoadTask),
             'busy heartbeat':   (1, Busy, None),
             'stop sent':        (1, _End, None)

--- a/sip_run.py
+++ b/sip_run.py
@@ -6,13 +6,16 @@ Current modules:
 - Master Controller RPC interface.
 - CSP visibility emulator
 """
+# Raise and exception if the interpreter isn't Python 3
+import sys
+if sys.version_info.major < 3:
+    raise RuntimeError('Please use Python V3')
+
 import argparse
 import logging
-import sys
 import simplejson as json
 import os
 import rpyc
-
 
 class SipRunner(object):
     """Class to run SIP modules.

--- a/slave/sip_slave/task_control.py
+++ b/slave/sip_slave/task_control.py
@@ -52,6 +52,14 @@ class TaskControl:
         """
         config.state = 'busy'
 
+    def set_slave_state_error(self):
+        """Update the slave state (global) to error.
+
+        The slave state is then sent to the master controller HeartbeatListener
+        by the slave controller.
+        """
+        config.state = 'error'
+
 
 class TaskControlProcessPoller(TaskControl):
     """Task controller for the visibility receiver.
@@ -157,7 +165,7 @@ class TaskControlExample(TaskControl):
         port = int(task[1])
 
         # Create a heartbeat listener to listen for a task
-        timeout_msec = 1000
+        timeout_msec = 10000
         heartbeat_comp_listener = heartbeat_task.Listener(timeout_msec)
         heartbeat_comp_listener.connect('localhost', port)
         self._poller = self._HeartbeatPoller(self, heartbeat_comp_listener)
@@ -181,8 +189,7 @@ class TaskControlExample(TaskControl):
     class _HeartbeatPoller(threading.Thread):
         """Polls for heartbeat messages from the task
 
-        When it get the message starting, state1, or state2 sets the slave state
-        to busy, otherwise set it to off.
+        When it gets a message it sets the state to busy.
         """
         def __init__(self, task_controller, heartbeat_comp_listener):
             """Constructor."""
@@ -199,24 +206,28 @@ class TaskControlExample(TaskControl):
             """Thread run method."""
             while not self._done.is_set():
 
-                # Listen to the task's heartbeat
+                # Listen to the task's heartbeat - this will wait for up
+                # to 10 seconds for a message
                 comp_msg = self._heartbeat_comp_listener.listen()
 
-                # Extract a task's state
-                state_task = self._get_state(comp_msg)
-
-                # If the task state changes log it
-                if state_task != self._state_task_prev:
-                    log.info('Slave task heartbeat message: ''{}'''.format(comp_msg))
-                    self._state_task_prev = state_task
-
-                # Update the controller state
-                if state_task == 'starting' or state_task == 'state1' or \
-                        state_task == 'state2':
-                    self._task_controller.set_slave_state_busy()
+                # If we don't get a message log a timeout
+                if comp_msg == '':
+                    log.info('Slave task heartbeat message: ''{}'''. \
+                            format(comp_msg))
+                    self._task_controller.set_slave_state_error()
                 else:
-                    config.state = state_task
-                time.sleep(1)
+
+                    # Extract a task's state
+                    state_task = self._get_state(comp_msg)
+
+                    # If the task state changes log it
+                    if state_task != self._state_task_prev:
+                        log.info('Slave task heartbeat message: ''{}'''. \
+                                format(comp_msg))
+                        self._state_task_prev = state_task
+
+                    # Update the controller state
+                    self._task_controller.set_slave_state_busy()
 
             # Set to idle before exiting.
             self._task_controller.set_slave_state_idle()
@@ -226,5 +237,5 @@ class TaskControlExample(TaskControl):
             """Extracts the state from the heartbeat message"""
             tokens = msg.split(" ")
             if len(tokens) < 4:
-                tokens = [' ', ' ', ' ', 'off', ' ', ' ']
+                tokens = [' ', ' ', ' ', '', ' ', ' ']
             return tokens[3]


### PR DESCRIPTION
This fixes some minor issues with the master and slave state machines plus some other niggles.

- sip_run now checks that you are using Python 3
- the slave controller now has an error state which they go into if the task heartbeats stop
- the system now works even if there are no tasks defined to be running when online
- tasks can now send a heartbeat message with the state 'finished'. The slave controller then goes back to idle and can be instructed to start another task. This means that you can re-use the same name to run a capability more than once.