### PR TITLE
Testsuite jenkins integration

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,4 +9,4 @@ spead2>=1.2.1
 Sphinx==1.5.1
 sphinx-rtd-theme>=0.1.9
 pyftpdlib>=1.4.0
-
+unittest-xml-reporting>=2.1.0

--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,11 @@ import platform
 from setuptools import setup, find_packages, Extension
 from setuptools.command.build_ext import build_ext
 from setuptools.command.install import install
+from setuptools.command.test import test
+
+import unittest
+import xmlrunner
+import sys
 
 # Define the extension modules to build.
 modules = [
@@ -52,6 +57,34 @@ class Install(install):
                 os.chmod(file_path, st.st_mode | 73)
 
 
+class Test(test):
+    """SIP Test suite class.
+    Runs either default test runner (outputs to console) or generates
+    JUNIT-compatible XML report for Jenkins when run with `-r xmlrunner`.
+    Inherits test."""
+
+    def finalize_options(self):
+        if not self.test_runner == None and self.test_runner.lower() == 'xmlrunner':
+            self.outfile = open('test_reports.xml', 'wb')
+            self.test_runner = xmlrunner.XMLTestRunner(output=self.outfile,failfast=False,buffer=True)
+        else:
+            # Silently default to TextTestRunner
+            self.test_runner = unittest.TextTestRunner()
+            self.outfile = None
+
+
+    def discover_tests(self):
+        """Greedy unittest discovery for all tests"""
+        loader = unittest.TestLoader()
+        self.test_suite = loader.discover('sip', pattern='*test*.py')
+
+    def run(self):
+        self.discover_tests()
+        self.test_runner.run(self.test_suite)
+        if self.outfile:
+            self.outfile.close()
+
+
 def get_sip_version():
     """Get the version of SIP from the version file."""
     globals_ = {}
@@ -89,5 +122,6 @@ setup(
     license='Apache',
     install_requires=['numpy'],
     setup_requires=['numpy'],
-    cmdclass={'build_ext': BuildExt, 'install': Install}
+    tests_require=['unittest-xml-reporting'],
+    cmdclass={'build_ext': BuildExt, 'install': Install, 'test':Test}
     )

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,6 @@ from setuptools.command.test import test
 
 import unittest
 import xmlrunner
-import sys
 
 # Define the extension modules to build.
 modules = [


### PR DESCRIPTION
Enables running all unit tests through `./setup.py test`, using unittest's auto-discovery to find tests (currently by matching `*test*.py`, since there isn't a consistent naming scheme in use at the moment)

Running `./setup.py test -r xmlrunner` will output the test results to a JUNIT-compatible file `test_reports.xml`, which can be used to integrate unittest results in the Jenkins build status.

Adds unittest-xml-reporting requirement.