### PR TITLE
Adds a timeout function to the state machine

### DIFF
--- a/sip/common/state_machine.py
+++ b/sip/common/state_machine.py
@@ -66,6 +66,23 @@ class State:
         pass
 
 
+class TimedState(State):
+    """ State with timeout
+
+        TimedState objects post an event after some period of time.
+    """
+    def __init__(self, sm, timeout, event):
+        """ Constructor
+        """
+
+        # Create and start a timeout object
+        self._t = threading.Timer(timeout, sm.post_event, [event])
+        self._t.start()
+
+    def exit(self):
+        self._t.cancel()
+
+
 class _End(State):
     """Pseudo end state.
 

--- a/sip/common/test/state_machine_test.py
+++ b/sip/common/test/state_machine_test.py
@@ -1,6 +1,8 @@
 import unittest
+import time
 
 from sip.common.state_machine import State
+from sip.common.state_machine import TimedState
 from sip.common.state_machine import StateMachine
 
 trace = []
@@ -22,6 +24,15 @@ class Online(State):
         trace.append("exiting online")
 
 
+class Wait(TimedState):
+    def __init__(self, sm):
+        TimedState.__init__(self, sm, 5, ["timeout"])
+        trace.append("entering wait")
+
+    def exit(self):
+        trace.append("exiting wait")
+
+
 class TestSM(StateMachine):
     def __init__(self):
         super(TestSM, self).__init__(self.state_table, Offline)
@@ -32,12 +43,19 @@ class TestSM(StateMachine):
     def action_online(self, event_name):
         trace.append("going online")
 
+    def action_wait(self, event_name):
+        trace.append("waiting")
+
     state_table = {
         'Offline': {
             'start': (1, Online,  action_online),
         },
         'Online' : {
             'stop' : (1, Offline, action_offline),
+            'wait' : (1, Wait, action_wait)
+        },
+        'Wait' : {
+            'timeout' : (1, Offline, action_offline),
         }
 }
 
@@ -52,6 +70,22 @@ class StateMachineTest(unittest.TestCase):
         self.sm.post_event(['start'])
         self.assertEqual(self.sm.current_state(), 'Online')
         self.sm.post_event(['stop'])
+        self.assertEqual(self.sm.current_state(), 'Offline')
+
+        self.assertEqual(trace[0], 'entering offline')
+        self.assertEqual(trace[1], 'exiting offline')
+        self.assertEqual(trace[2], 'going online')
+        self.assertEqual(trace[3], 'entering online')
+        self.assertEqual(trace[4], 'exiting online')
+        self.assertEqual(trace[5], 'going offline')
+        self.assertEqual(trace[6], 'entering offline')
+
+    def testTimer(self):
+        self.sm.post_event(['start'])
+        self.assertEqual(self.sm.current_state(), 'Online')
+        self.sm.post_event(['wait'])
+        self.assertEqual(self.sm.current_state(), 'Wait')
+        time.sleep(10)
         self.assertEqual(self.sm.current_state(), 'Offline')
 
         self.assertEqual(trace[0], 'entering offline')

--- a/sip/master/master_states.py
+++ b/sip/master/master_states.py
@@ -12,6 +12,7 @@ __author__ = 'David Terrett'
 
 from sip.common.logging_api import log
 from sip.common.state_machine import State
+from sip.common.state_machine import TimedState
 from sip.common.state_machine import StateMachine
 from sip.common.state_machine import _End
 from sip.master.capability import Capability
@@ -26,15 +27,17 @@ class Standby(State):
         log.info('state->standby')
 
 
-class Configuring(State):
+class Configuring(TimedState):
     """Configuring state."""
     def __init__(self, sm):
+        TimedState.__init__(self, sm, 30, ["configure_timeout"])
         log.info('state->configuring')
 
 
-class UnConfiguring(State):
+class UnConfiguring(TimedState):
     """Unconfiguring state."""
     def __init__(self, sm):
+        TimedState.__init__(self, sm, 30, ["unconfigure_timeout"])
         log.info('state->unconfiguring')
 
 
@@ -90,6 +93,7 @@ class MasterControllerSM(StateMachine):
         },
         'Configuring': {
             'all services':     (1, Available, None),
+            'configure_timeout':(1, Unavailable, None),
             'offline':          (1, UnConfiguring, offline),
             'online':           (0, None, None),
             'shutdown':         (0, None, None)
@@ -117,6 +121,7 @@ class MasterControllerSM(StateMachine):
         },
         'UnConfiguring': {
             'no tasks':         (1, Standby, None),
+            'unconfigure_timeout':(1, Standby, None),
             'offline':          (0, None, None),
             'online':           (0, None, None),
             'shutdown':         (0, None, None)


### PR DESCRIPTION
There is now a state machine State class called TimedState which
posts an event if the state hasn't been exited after some interval.

The master controller state machine uses this for the configuring
state and posts an configuring_timeout event after 30s. This event
moves the state machine into the unavailable state.

There is a similar timeout for the uncofiguring state that puts the
statemachine into the standby state.