### PR TITLE
Continuous deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,20 +2,22 @@ FROM ubuntu
 MAINTAINER David Terrett
 USER root
 
-# Install Python 3 and pip
-RUN apt-get -y update 
-RUN apt-get -y install docker
-RUN apt-get -y install python3 python3-pip
-RUN apt-get -y install libboost-program-options-dev
-RUN apt-get -y install libboost-system-dev
-RUN apt-get -y install libboost-python-dev
-RUN apt-get -y install python-numpy-dev
+RUN adduser --disabled-password -gecos 'unprivileged user' sdp
+
+# Install dependencies, and clear cache
+RUN apt-get -y update \
+ && apt-get -y install docker \
+ python3 \
+ python3-pip \
+ libboost-program-options-dev \
+ libboost-system-dev \
+ libboost-python-dev \
+ python-numpy-dev \
+ dnsutils \
+ && rm -rf /var/lib/apt/lists/*
+
 COPY requirements.txt .
 RUN python3 -m pip install -r requirements.txt
-RUN apt-get -y install dnsutils
-
-# Create non-privileged user
-RUN adduser --disabled-password -gecos 'unprivileged user' sdp
 
 # Set working directory
 WORKDIR /home/sdp

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,7 +4,15 @@ pipeline {
 	stages {
 		stage('Setup') {
 			steps {
+				// Get digests for current -latest and -stable docker images
+				// and save to file. We need these so we can delete the old
+				// images when pushing the new ones to the registry
 				// Set up fresh Python virtual environment
+				sh '''
+				  /usr/local/bin/get_reg_digest.sh localhost:5000 sip ${JOB_BASE_NAME}-latest > dockerimage.digest
+				  /usr/local/bin/get_reg_digest.sh localhost:5000 sip ${JOB_BASE_NAME}-stable > dockerimage-stable.digest
+				'''
+
 				sh '''
 					# Need to rm old virtualenv dir or else PIP will try to
 					# to install a hybrid old/new version. I don't get it
@@ -58,11 +66,12 @@ pipeline {
 		stage('Build SIP') {
 			steps {
 				// build and install SIP, build containers
+				// Tag container with branch name (JOB_BASE_NAME)
 				sh '''
 					. _build/bin/activate
 
 					python3 ./setup.py install
-					docker build -t sip .
+					docker build -t sip:${JOB_BASE_NAME} .
 				'''
 			}
 		}
@@ -90,10 +99,37 @@ pipeline {
 				junit 'test_reports.xml'
 			}
 		}
-		stage('Deploy') {
-			steps {
-				echo 'To be implemented'
-			}
+	}
+	post {
+		success {
+			echo 'Build stable. Pushing image as -latest and -stable.'
+
+			// Push -stable
+			sh '''
+				/usr/local/bin/delete_from_reg.sh localhost:5000 sip `cat dockerimage-stable.digest`
+				sh 'docker tag sip:${JOB_BASE_NAME} localhost:5000/sip:${JOB_BASE_NAME}-stable
+				sh 'docker push localhost:5000/sip:${JOB_BASE_NAME}-stable
+			'''
+
+			// Push -latest
+			sh '''
+				'/usr/local/bin/delete_from_reg.sh localhost:5000 sip `cat	dockerimage.digest`
+				'docker tag sip:${JOB_BASE_NAME} localhost:5000/sip:${JOB_BASE_NAME}-latest
+				'docker push localhost:5000/sip:${JOB_BASE_NAME}-latest
+			'''
+		}
+		unstable {
+			echo 'Build unstable. Only pushing -latest image.'
+
+			// Push -latest
+			sh '''
+				/usr/local/bin/delete_from_reg.sh localhost:5000 sip `cat	dockerimage.digest`
+				docker tag sip:${JOB_BASE_NAME} localhost:5000/sip:${JOB_BASE_NAME}-latest
+				docker push localhost:5000/sip:${JOB_BASE_NAME}-latest
+			'''
+		}
+		failure {
+			echo 'Build failure. No images pushed to registry.'
 		}
 	}
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,12 +7,12 @@ pipeline {
 				// Get digests for current -latest and -stable docker images
 				// and save to file. We need these so we can delete the old
 				// images when pushing the new ones to the registry
-				// Set up fresh Python virtual environment
 				sh '''
 				  /usr/local/bin/get_reg_digest.sh localhost:5000 sip ${JOB_BASE_NAME}-latest > dockerimage.digest
 				  /usr/local/bin/get_reg_digest.sh localhost:5000 sip ${JOB_BASE_NAME}-stable > dockerimage-stable.digest
 				'''
 
+				// Set up fresh Python virtual environment
 				sh '''
 					# Need to rm old virtualenv dir or else PIP will try to
 					# to install a hybrid old/new version. I don't get it

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -113,7 +113,7 @@ pipeline {
 
 			// Push -latest
 			sh '''
-				'/usr/local/bin/delete_from_reg.sh localhost:5000 sip `cat	dockerimage.digest`
+				'/usr/local/bin/delete_from_reg.sh localhost:5000 sip `cat dockerimage.digest`
 				'docker tag sip:${JOB_BASE_NAME} localhost:5000/sip:${JOB_BASE_NAME}-latest
 				'docker push localhost:5000/sip:${JOB_BASE_NAME}-latest
 			'''
@@ -123,7 +123,7 @@ pipeline {
 
 			// Push -latest
 			sh '''
-				/usr/local/bin/delete_from_reg.sh localhost:5000 sip `cat	dockerimage.digest`
+				/usr/local/bin/delete_from_reg.sh localhost:5000 sip `cat dockerimage.digest`
 				docker tag sip:${JOB_BASE_NAME} localhost:5000/sip:${JOB_BASE_NAME}-latest
 				docker push localhost:5000/sip:${JOB_BASE_NAME}-latest
 			'''


### PR DESCRIPTION
Lets Jenkins build and tag Docker containers appropriately (by branch name and build stability). Currently pushing to a registry local to the Jenkins server, will update to the proper registry once this method is approved.

This is just a suggestion, feel free to reject if you don't agree (or merge if you do ;) )

Also includes a small update to the Dockerfile to keep the containers slightly cleaner.