### PR TITLE
Docker service workaround

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -138,5 +138,6 @@ pipeline {
 			// Keep until problem is fixed (`docker service ls` should be empty)
 			sh 'docker service ls'
 			sh 'docker service rm `docker service ls -q`'
+		}
 	}
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -131,5 +131,12 @@ pipeline {
 		failure {
 			echo 'Build failure. No images pushed to registry.'
 		}
+		always {
+			// Some of the Docker services tend to go haywire and kill Jenkins
+			// They should all be removed, or at least fully stopped
+			// This hackaround kills all services
+			// Keep until problem is fixed (`docker service ls` should be empty)
+			sh 'docker service ls
+			sh 'docker service rm `docker service ls -q`'
 	}
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -136,7 +136,7 @@ pipeline {
 			// They should all be removed, or at least fully stopped
 			// This hackaround kills all services
 			// Keep until problem is fixed (`docker service ls` should be empty)
-			sh 'docker service ls
+			sh 'docker service ls'
 			sh 'docker service rm `docker service ls -q`'
 	}
 }


### PR DESCRIPTION
There are issues with the test docker services not terminating properly, which causes docker to start containers in a loop, eventually crashing the server.. This addition to the Jenkinsfile makes sure all services are terminated forcefully after testing completes.