### PR TITLE
Fix build terminating when no Docker services are running (oops)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -149,7 +149,7 @@ pipeline {
 			// This hackaround kills all services
 			// Keep until problem is fixed (`docker service ls` should be empty)
 			sh 'docker service ls'
-			sh 'docker service rm `docker service ls -q`'
+			sh 'docker service rm `docker service ls -q` | true'
 		}
 	}
 }


### PR DESCRIPTION
When no services are running, `docker service rm ...` returns non-zero, failing the Jenkins build.