### PR TITLE
Fixed errors & warnings raised by the latest version of pylint

### DIFF
--- a/sip/execution_control/processing_controller_interface/flask_api/app/db/client.py
+++ b/sip/execution_control/processing_controller_interface/flask_api/app/db/client.py
@@ -68,6 +68,7 @@ class ConfigDb:
                                     value["status"],
                                     value["id"])
         except ValidationError:
+            LOG.critical('Invalid SBI configuration!')
             raise
 
     # #########################################################################

--- a/sip/execution_control/processing_controller_interface/flask_api/app/db/client.py
+++ b/sip/execution_control/processing_controller_interface/flask_api/app/db/client.py
@@ -6,7 +6,7 @@ import json
 import logging
 import os
 
-from jsonschema import ValidationError, validate
+from jsonschema import validate
 
 from .config_db_redis import ConfigDB
 
@@ -29,47 +29,48 @@ class ConfigDb:
     ###########################################################################
 
     def add_sched_block_instance(self, config_dict):
-        """Add Scheduling Block to the database"""
+        """Add Scheduling Block to the database.
+
+        Args:
+            config_dict (dict): SBI configuration
+
+        """
         # Get schema for validation
         schema = self._get_schema()
         LOG.debug('Adding SBI with config: %s', config_dict)
 
-        try:
-            # Validates the schema
-            validate(config_dict, schema)
+        # Validates the schema
+        validate(config_dict, schema)
 
-            # Add status field and value to the data
-            updated_block = self._add_status(config_dict)
+        # Add status field and value to the data
+        updated_block = self._add_status(config_dict)
 
-            # Splitting into different names and fields before
-            # adding to the database
-            scheduling_block_data, processing_block_data = \
-                self._split_sched_block_instance(updated_block)
+        # Splitting into different names and fields before
+        # adding to the database
+        scheduling_block_data, processing_block_data = \
+            self._split_sched_block_instance(updated_block)
 
-            # Adding Scheduling block instance with id
-            name = "scheduling_block:" + updated_block["id"]
-            self._db.set_specified_values(name, scheduling_block_data)
+        # Adding Scheduling block instance with id
+        name = "scheduling_block:" + updated_block["id"]
+        self._db.set_specified_values(name, scheduling_block_data)
 
-            # Add a event to the scheduling block event list to notify
-            # of a new scheduling block being added to the db.
-            self._db.push_event(self.scheduling_event_name,
-                                updated_block["status"],
-                                updated_block["id"])
+        # Add a event to the scheduling block event list to notify
+        # of a new scheduling block being added to the db.
+        self._db.push_event(self.scheduling_event_name,
+                            updated_block["status"],
+                            updated_block["id"])
 
-            # Adding Processing block with id
-            for value in processing_block_data:
-                name = ("scheduling_block:" + updated_block["id"] +
-                        ":processing_block:" + value['id'])
-                self._db.set_specified_values(name, value)
+        # Adding Processing block with id
+        for value in processing_block_data:
+            name = ("scheduling_block:" + updated_block["id"] +
+                    ":processing_block:" + value['id'])
+            self._db.set_specified_values(name, value)
 
-                # Add a event to the processing block event list to notify
-                # of a new processing block being added to the db.
-                self._db.push_event(self.processing_event_name,
-                                    value["status"],
-                                    value["id"])
-        except ValidationError:
-            LOG.critical('Invalid SBI configuration!')
-            raise
+            # Add a event to the processing block event list to notify
+            # of a new processing block being added to the db.
+            self._db.push_event(self.processing_event_name,
+                                value["status"],
+                                value["id"])
 
     # #########################################################################
     # Get functions

--- a/sip/execution_control/processing_controller_interface/flask_api/app/db/config_db_redis.py
+++ b/sip/execution_control/processing_controller_interface/flask_api/app/db/config_db_redis.py
@@ -11,8 +11,8 @@ import redis.exceptions
 
 LOG = logging.getLogger('SIP.EC.PCI.DB')
 REDIS_HOST = os.getenv('REDIS_HOST', 'localhost')
-REDIS_DB_ID = os.getenv('REDIS_DB_ID', 0)
-REDIS_PORT = os.getenv('REDIS_PORT', 6379)
+REDIS_DB_ID = os.getenv('REDIS_DB_ID', '0')
+REDIS_PORT = os.getenv('REDIS_PORT', '6379')
 
 
 def check_connection(func):

--- a/sip/execution_control/processing_controller_interface/flask_api/app/db/init.py
+++ b/sip/execution_control/processing_controller_interface/flask_api/app/db/init.py
@@ -74,6 +74,7 @@ def add_scheduling_blocks(num_blocks, clear=True):
                      len(config['processing_blocks']))
             db_client.add_sched_block_instance(config)
     except ValidationError:
+        LOG.critical('Invalid SBI configuration!')
         raise
 
 

--- a/sip/execution_control/processing_controller_interface/flask_api/app/db/init.py
+++ b/sip/execution_control/processing_controller_interface/flask_api/app/db/init.py
@@ -13,7 +13,6 @@ import random
 import sys
 from time import gmtime, strftime
 
-from jsonschema import ValidationError
 
 from .client import ConfigDb
 
@@ -67,15 +66,11 @@ def add_scheduling_blocks(num_blocks, clear=True):
         start_pb_id = len(db_client.get_processing_block_ids())
 
     LOG.info("Adding %i SBIs to the db", num_blocks)
-    try:
-        for config in _scheduling_block_config(num_blocks, start_sbi_id,
-                                               start_pb_id):
-            LOG.info('Creating SBI %s with %i PBs.', config['id'],
-                     len(config['processing_blocks']))
-            db_client.add_sched_block_instance(config)
-    except ValidationError:
-        LOG.critical('Invalid SBI configuration!')
-        raise
+    for config in _scheduling_block_config(num_blocks, start_sbi_id,
+                                           start_pb_id):
+        LOG.info('Creating SBI %s with %i PBs.', config['id'],
+                 len(config['processing_blocks']))
+        db_client.add_sched_block_instance(config)
 
 
 def main():

--- a/sip/execution_control/processing_controller_interface/flask_api/app/db/mock/client.py
+++ b/sip/execution_control/processing_controller_interface/flask_api/app/db/mock/client.py
@@ -11,7 +11,7 @@ import redis
 
 # Get Redis database object
 REDIS_HOST = os.getenv('REDIS_HOST', 'localhost')
-REDIS_DB_ID = os.getenv('REDIS_DB_ID', 0)
+REDIS_DB_ID = os.getenv('REDIS_DB_ID', '0')
 POOL = redis.ConnectionPool(host=REDIS_HOST, db=REDIS_DB_ID,
                             decode_responses=True)
 DB = redis.StrictRedis(connection_pool=POOL)


### PR DESCRIPTION
It turns out that this code was using `os.getenv()` defaults incorrectly and immediately raising exceptions in a few cases needlessly. This small pull request fixes those issues.