### PR TITLE
Downgraded EC configuration database redis version from 3.0.1 to 2.10.6

### DIFF
--- a/sip/execution_control/configuration_db/CHANGELOG.md
+++ b/sip/execution_control/configuration_db/CHANGELOG.md
@@ -8,6 +8,12 @@ The format is based on
 and this project adheres to
  [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.1] - 2018-12-04
+
+### Changed
+- Downgraded to `redis==2.10.6` to address PBC celery issue 
+  https://github.com/celery/celery/issues/5175
+
 ## [1.2.0] - 2018-11-26
 
 ### Fixed

--- a/sip/execution_control/configuration_db/docker-compose.yml
+++ b/sip/execution_control/configuration_db/docker-compose.yml
@@ -13,17 +13,3 @@ services:
     - REDIS_HOSTS=config_db:config_db:6379:0
     ports:
     - 8081:8081
-
-#  redis-commander-db0:
-#    image: tenstartups/redis-commander:latest
-#    command: ["--redis-host", "config_db"]
-#    ports:
-#    - 8081:8081
-
-  portainer:
-    image: portainer/portainer:1.19.2
-    ports:
-      - 9000:9000
-    command: -H unix:///var/run/docker.sock
-    volumes:
-      - /var/run/docker.sock:/var/run/docker.sock

--- a/sip/execution_control/configuration_db/setup.py
+++ b/sip/execution_control/configuration_db/setup.py
@@ -47,7 +47,7 @@ setup(name='skasip_config_db',
       package_data={'': DATA + TEST_DATA + SCHEMA},
       include_package_data=True,
       install_requires=[
-          'redis==3.0.1',
+          'redis==2.10.6',
           'jsonschema==2.6.0',
           'jinja2==2.10',
           'PyYAML==3.13'

--- a/sip/execution_control/configuration_db/sip_config_db/_config_db_redis.py
+++ b/sip/execution_control/configuration_db/sip_config_db/_config_db_redis.py
@@ -479,9 +479,16 @@ class ConfigDb:
 
         """
         if pipeline:
-            self._pipeline.lrem(key, count, value)
+            if redis.__version__ == '2.10.6':
+                self._pipeline.lrem(name=key, value=value, num=count)
+            else:
+                self._pipeline.lrem(key, count, value)
         else:
-            self._db.lrem(key, count, value)
+            if self._db.exists(key):
+                if redis.__version__ == '2.10.6':
+                    self._db.lrem(name=key, value=value, num=count)
+                else:
+                    self._db.lrem(key, count, value)
 
     @check_connection
     def execute(self):

--- a/sip/execution_control/configuration_db/sip_config_db/release.py
+++ b/sip/execution_control/configuration_db/sip_config_db/release.py
@@ -1,6 +1,6 @@
 # coding=utf-8
 """Release information for the SIP Execution Control Configuration Database."""
-__version_info__ = (1, 2, 0)
+__version_info__ = (1, 2, 1)
 __version__ = '.'.join(map(str, __version_info__))
 __sbi_version__ = "1.0.0"
 __pb_version__ = "1.0.0"

--- a/sip/execution_control/configuration_db/sip_config_db/tests/test_config_db_redis.py
+++ b/sip/execution_control/configuration_db/sip_config_db/tests/test_config_db_redis.py
@@ -12,8 +12,8 @@ def test_config_db_version():
     """Make sure we are using the version we expect!"""
     from .. import __version__
     import redis
-    assert __version__ == '1.2.0'
-    assert redis.__version__ == '3.0.1'
+    assert __version__ == '1.2.1'
+    assert redis.__version__ == '2.10.6'
 
 
 @pytest.mark.parametrize('hierarchical', [True, False])


### PR DESCRIPTION
Downgraded to redis 2.10.6 as a work around for celery issue 5175 (https://github.com/celery/celery/issues/5175). It turns out that using redis 3.0.1 is currently incompatible as a redis backend to Celery, which is used by the SIP Processing Block Controller (PBC) and pulling in a redis 3.0.1 dependency in the configuration database therefore breaks the PBC.

## Description:
- Downgraded package dependency to redis 2.10.6 (from 3.0.1)
- Adjusted use of `lrem` to work with 2.10.6

## Testing instructions:
- Changes have been tested against current set of unit tests.
- To repeat these tests (from the top level SIP repo directory):
    - Starting a Redis Db instance:
       `docker stack deploy -c sip/execution_control/configuration_db/docker-compose.yml db`
    - Running the unit tests as follows:
    `./tools/run_tests.sh sip/execution_control/configuration_db`

## Types of changes
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] The code follows the code style of this project.
- [ ] The changes require a documentation update.
- [ ] Documentation has been updated accordingly.
- [x] Tests cover all changes in this PR.
- [x] All new and existing tests passed.

## Notes
- Unit test coverage slightly decreased as the update to the handling of `lrem` is designed to work with both redis 3.0.1 and 2.10.6 but in this pull request, only the redis 2.10.6 routes are tested.
