### PR TITLE
Updated PBC (&PC) to use the new Docker Swarm Client API (v1.0.7)

### DIFF
--- a/deploy/demos_23_11_18/docker-compose.yml
+++ b/deploy/demos_23_11_18/docker-compose.yml
@@ -84,7 +84,7 @@ services:
       replicas: 1
 
   ec_processing_controller:
-    image: skasip/processing_controller:1.2.2
+    image: skasip/processing_controller:1.2.3
     environment:
     - CELERY_BROKER_URL=redis://ec_config_database/1
     - CELERY_RESULT_BACKEND=redis://ec_config_database/2
@@ -94,7 +94,7 @@ services:
       replicas: 1
 
   ec_processing_block_controller:
-    image: skasip/processing_block_controller:1.2.3
+    image: skasip/processing_block_controller:1.2.4
     environment:
     - CELERY_BROKER_URL=redis://ec_config_database/1
     - CELERY_RESULT_BACKEND=redis://ec_config_database/2

--- a/sip/execution_control/processing_block_controller/CHANGELOG.md
+++ b/sip/execution_control/processing_block_controller/CHANGELOG.md
@@ -8,9 +8,14 @@ The format is based on
 and this project adheres to
  [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.4] - 2018-12/14
+
+### Changed
+- Updated to `skasip-docker-swarm==1.0.7`
+
 ## [1.2.3] - 2018-12-07
 
-## Changed
+### Changed
 - Added optional log_level argument to the `execute_processing_block`
   task which sets the python logging level.
 

--- a/sip/execution_control/processing_block_controller/requirements.txt
+++ b/sip/execution_control/processing_block_controller/requirements.txt
@@ -1,5 +1,5 @@
 skasip-config-db==1.2.1
-skasip-docker-swarm==1.0.5
+skasip-docker-swarm==1.0.7
 skasip-logging==1.0.14
 redis==2.10.6
 jinja2==2.10

--- a/sip/execution_control/processing_block_controller/setup.py
+++ b/sip/execution_control/processing_block_controller/setup.py
@@ -17,7 +17,7 @@ setup(name='skasip-pbc',
       packages=['sip_pbc'],
       install_requires=[
           'skasip-config-db==1.2.1',
-          'skasip-docker-swarm==1.0.5',
+          'skasip-docker-swarm==1.0.7',
           'skasip-logging==1.0.14',
           'redis==2.10.6',
           'jinja2==2.10',

--- a/sip/execution_control/processing_block_controller/sip_pbc/release.py
+++ b/sip/execution_control/processing_block_controller/sip_pbc/release.py
@@ -2,7 +2,7 @@
 """Processing Block Controller release info."""
 __subsystem__ = 'ExecutionControl'
 __service_name__ = 'ProcessingBlockController'
-__version_info__ = (1, 2, 3)
+__version_info__ = (1, 2, 4)
 __version__ = '.'.join(map(str, __version_info__))
 __service_id__ = ':'.join(map(str, (__subsystem__,
                                     __service_name__,

--- a/sip/execution_control/processing_block_controller/sip_pbc/tasks.py
+++ b/sip/execution_control/processing_block_controller/sip_pbc/tasks.py
@@ -16,7 +16,8 @@ from celery import Celery
 
 from sip_config_db.scheduling import ProcessingBlock, ProcessingBlockList
 from sip_config_db.scheduling.workflow_stage import WorkflowStage
-from sip_docker_swarm import DockerClient, __version__ as sip_swarm_api_version
+from sip_docker_swarm import DockerSwarmClient, __version__ \
+    as sip_swarm_api_version
 from sip_logging import init_logger
 from .release import LOG, __version__
 
@@ -53,7 +54,7 @@ def version():
 def _start_workflow_stages(pb: ProcessingBlock, pb_id: str,
                            workflow_stage_dict: dict,
                            workflow_stage: WorkflowStage,
-                           docker: DockerClient):
+                           docker: DockerSwarmClient):
     """Start a workflow stage by starting a number of docker services.
 
     This function first assesses if the specified workflow stage can be
@@ -142,7 +143,7 @@ def _start_workflow_stages(pb: ProcessingBlock, pb_id: str,
 
 
 def _update_workflow_stages(stage_data: dict, workflow_stage: WorkflowStage,
-                            docker: DockerClient):
+                            docker: DockerSwarmClient):
     """Check and update the status of a workflow stage.
 
     This function checks and updates the status of a workflow stage
@@ -186,7 +187,7 @@ def _update_workflow_stages(stage_data: dict, workflow_stage: WorkflowStage,
 
 
 def _abort_workflow(pb: ProcessingBlock, workflow_stage_dict: dict,
-                    docker: DockerClient):
+                    docker: DockerSwarmClient):
     """Abort the workflow.
 
     TODO(BMo): This function currently does nothing as the abort flag
@@ -264,7 +265,7 @@ def execute_processing_block(pb_id: str, log_level='DEBUG'):
     LOG.info('Starting workflow %s %s', pb.workflow_id, pb.workflow_version)
 
     pb.set_status('running')
-    docker = DockerClient()
+    docker = DockerSwarmClient()
 
     # Coping workflow stages to a dict
     workflow_stage_dict = {}

--- a/sip/execution_control/processing_controller/CHANGELOG.md
+++ b/sip/execution_control/processing_controller/CHANGELOG.md
@@ -8,6 +8,12 @@ The format is based on
 and this project adheres to
  [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.3] - 2018-12-14
+
+### Changed
+- Updated to `skasip-pbc==1.2.4`
+
+
 ## [1.2.2] - 2018-12-10
 
 ### Changed

--- a/sip/execution_control/processing_controller/requirements.txt
+++ b/sip/execution_control/processing_controller/requirements.txt
@@ -1,6 +1,6 @@
-skasip-pbc==1.2.3
+skasip-pbc==1.2.4
 skasip-config-db==1.2.1
-skasip-docker-swarm==1.0.5
+skasip-docker-swarm==1.0.7
 skasip-logging==1.0.14
 jinja2==2.10
 celery==4.2.1

--- a/sip/execution_control/processing_controller/scheduler/release.py
+++ b/sip/execution_control/processing_controller/scheduler/release.py
@@ -2,7 +2,7 @@
 """Processing Controller release info."""
 __subsystem__ = 'ExecutionControl'
 __service_name__ = 'ProcessingController'
-__version_info__ = (1, 2, 2)
+__version_info__ = (1, 2, 3)
 __version__ = '.'.join(map(str, __version_info__))
 __service_id__ = ':'.join(map(str, (__subsystem__,
                                     __service_name__,


### PR DESCRIPTION
## Description:
- Updated PBC library and image to use `skasip-docker-swarm==1.0.7`.
- Updated PC image to use new PBC library.

***Ready to be merged into master as soon as approved.***

## Testing instructions:
Start a Configuration Database (Redis) container exposing port 6379 to localhost. ie

```bash
docker service create -p 6379:6379 --name=config_db redis:5.0.1-alpine
```

Unit tests (unchanged by this pull request) can then be run with 

```bash
./tools/run_tests.sh sip/execution_control/processing_block_controller
./tools/run_tests.sh sip/execution_control/processing_controller
```

## Types of changes
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] The code follows the code style of this project.
- [ ] The changes require a documentation update.
- [ ] Documentation has been updated accordingly.
- [x] Tests cover all changes in this PR.
- [x] All new and existing tests passed.
