### PR TITLE
Add device server "ping" as healthcheck for Tango servers

### DIFF
--- a/deploy/demos_23_11_18/docker-compose.yml
+++ b/deploy/demos_23_11_18/docker-compose.yml
@@ -14,6 +14,13 @@ services:
     deploy:
       mode: replicated
       replicas: 1
+    healthcheck:
+      test: ["CMD", "python3", "-c",
+            "import PyTango; d=PyTango.DeviceProxy('sip_sdp/elt/master');
+            d.ping()"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
 
   tc_tango_subarray:
     image: skasip/tango_subarray:1.2.0
@@ -23,6 +30,13 @@ services:
     deploy:
       mode: replicated
       replicas: 1
+    healthcheck:
+      test: ["CMD", "python3", "-c",
+            "import PyTango; d=PyTango.DeviceProxy('sip_sdp/elt/subarray_00');
+            d.ping()"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
 
   tc_tango_processing_block:
     image: skasip/tango_processing_block:1.2.0
@@ -32,6 +46,13 @@ services:
     deploy:
       mode: replicated
       replicas: 1
+    healthcheck:
+      test: ["CMD", "python3", "-c",
+             "import PyTango; d=PyTango.DeviceProxy('sip_sdp/pb/00000');
+             d.ping()"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
 
   tc_tango_database:
     image: skasip/tango_database:1.0.4


### PR DESCRIPTION
Adds a healthchewck - using the builtin Tango Device Server "ping()" command to all the Tango SIP device servers

## Description:

JIRA ticket TSK-2704

## Testing instructions:
Use **docker-stack deploy -C docker-compose sip** command from deploy/demos_23_11_18 directory

Observe (Healthy) status on Tango device servers. **docker inspect** for healthcheck logs

## Types of changes
<!-- What types of changes does this PR introduce? Put an 'x' in all of the boxes that apply. -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!-- Go over all of the following points and put and 'x' in the boxes that apply. -->
- [ ] The code follows the code style of this project.
- [ ] The changes require a documentation update.
- [ ] Documentation has been updated accordingly.
- [ ] Tests cover all changes in this PR.
- [ ] All new and existing tests passed.
