### PR TITLE
Fixed PC runtime issue by removed an assert in PB for specific PBC version

### DIFF
--- a/deploy/demos_23_11_18/docker-compose.yml
+++ b/deploy/demos_23_11_18/docker-compose.yml
@@ -111,7 +111,7 @@ services:
       replicas: 1
 
   ec_processing_controller:
-    image: skasip/processing_controller:1.2.3
+    image: skasip/processing_controller:1.2.4
     environment:
     - CELERY_BROKER_URL=redis://ec_config_database/1
     - CELERY_RESULT_BACKEND=redis://ec_config_database/2
@@ -121,7 +121,7 @@ services:
       replicas: 1
 
   ec_processing_block_controller:
-    image: skasip/processing_block_controller:1.2.4
+    image: skasip/processing_block_controller:1.2.5
     environment:
     - CELERY_BROKER_URL=redis://ec_config_database/1
     - CELERY_RESULT_BACKEND=redis://ec_config_database/2
@@ -143,7 +143,7 @@ services:
     - sip_config_database:/data/db
 
   # ==========================================================================
-  # Platform containers ?
+  # Platform containers
   # ==========================================================================
 
   platform_redis-commander-db0:

--- a/sip/execution_control/processing_controller/CHANGELOG.md
+++ b/sip/execution_control/processing_controller/CHANGELOG.md
@@ -8,11 +8,14 @@ The format is based on
 and this project adheres to
  [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.4] - 2019-01-09
+### Changed
+- Disabled check on the PBC API version.
+
 ## [1.2.3] - 2018-12-14
 
 ### Changed
 - Updated to `skasip-pbc==1.2.4`
-
 
 ## [1.2.2] - 2018-12-10
 

--- a/sip/execution_control/processing_controller/scheduler/release.py
+++ b/sip/execution_control/processing_controller/scheduler/release.py
@@ -2,7 +2,7 @@
 """Processing Controller release info."""
 __subsystem__ = 'ExecutionControl'
 __service_name__ = 'ProcessingController'
-__version_info__ = (1, 2, 3)
+__version_info__ = (1, 2, 4)
 __version__ = '.'.join(map(str, __version_info__))
 __service_id__ = ':'.join(map(str, (__subsystem__,
                                     __service_name__,

--- a/sip/execution_control/processing_controller/scheduler/scheduler.py
+++ b/sip/execution_control/processing_controller/scheduler/scheduler.py
@@ -173,7 +173,9 @@ class ProcessingBlockScheduler:
 
     def start(self):
         """Start the scheduler threads."""
-        assert sip_pbc.release.__version__ == '1.2.3'
+        # TODO(BMo) having this check is probably a good idea but I've \
+        # disabled it for now while the PBC is in flux.
+        # assert sip_pbc.release.__version__ == '1.2.3'
 
         scheduler_threads = [
             Thread(target=self._monitor_events, daemon=True),

--- a/sip/execution_control/processing_controller/scheduler/scheduler.py
+++ b/sip/execution_control/processing_controller/scheduler/scheduler.py
@@ -10,7 +10,6 @@ from threading import Thread, active_count
 
 import celery
 from celery.app.control import Inspect
-import sip_pbc.release
 from sip_pbc.tasks import APP, execute_processing_block
 
 from sip_config_db.scheduling import ProcessingBlock, ProcessingBlockList


### PR DESCRIPTION
## Description:
- Fixed an issue where the PC fails due to an incorrect PBC version assert.
  - Removed assert in the PC requiring a specific PBC version.
     With the PBC in a state of flux while this check had good motivations
     it is currently causing too many problems.
- Updated the PC and PBC image versions used in the demos to the
  latest versions to avoid any issues with incompatible interactions
  between the PBC and PC.

## Testing instructions:
Demos can now be run according to the description i the Nov 23rd 2018 demos day slides.

## Types of changes
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] The code follows the code style of this project.
- [ ] The changes require a documentation update.
- [ ] Documentation has been updated accordingly.
- [x] Tests cover all changes in this PR.
- [x] All new and existing tests passed.
