### PR TITLE
Update test script with option to ignore linters and code coverage

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -3,4 +3,8 @@ branch = True
 omit =
     */__main__.py
     */__init__.py
+    */setup.py
 
+[report]
+skip_covered = True
+sort = Cover

--- a/tools/run_tests.sh
+++ b/tools/run_tests.sh
@@ -1,18 +1,38 @@
 #!/usr/bin/env bash
 # Run tests and linters for specified directory.
+#
+# Usage:
+#   ./tools/run_tests.sh <directory> [--test-only] [pytest flags]
+#
+# Example:
+#   ./tools/run_tests.sh sip/execution_control/configuration_db \
+#        --test-only -x -k test_workflow_definitions
+#
 RED='\033[0;31m'
 BLUE='\033[0;34m'
 NC='\033[0m'
 
 DIR="$1"
 echo -e "${RED}* DIR=${NC}'${DIR}'"
-OPTIONS="${@:2}"
-if [[ ! -z "${OPTIONS}" ]]; then
+OPTIONS=("${@:2}")
+if [[ ! -z "${OPTIONS}" && "${OPTIONS[0]}" == "--test-only" ]]; then
+    OPTIONS="${OPTIONS[@]:1}"
     echo -e "${RED}------------------------------------------------------${NC}"
     echo -e "${RED}* OPTIONS=${NC}'${OPTIONS}'"
     CMD="python3 -m pytest -s -v \
     --rootdir=. \
-    --pylint ${OPTIONS} \
+    ${OPTIONS[*]} \
+    ${DIR}"
+    echo -e "${RED}------------------------------------------------------${NC}"
+    echo -e "${BLUE}Running tests:"
+    echo -e "${BLUE}${CMD}"
+    echo -e "${RED}------------------------------------------------------${NC}"
+elif [[ ! -z "${OPTIONS}" ]]; then
+    echo -e "${RED}------------------------------------------------------${NC}"
+    echo -e "${RED}* OPTIONS=${NC}'${OPTIONS}'"
+    CMD="python3 -m pytest -s -v \
+    --rootdir=. \
+    --pylint \
     --pylint-rcfile=.pylintrc \
     --codestyle \
     --docstyle \
@@ -20,7 +40,9 @@ if [[ ! -z "${OPTIONS}" ]]; then
     --cov-append \
     --cov-branch \
     --no-cov-on-fail \
-    --cov=${DIR} ${DIR}"
+    --cov=${DIR} \
+    ${OPTIONS[*]} \
+    ${DIR}"
     echo -e "${RED}------------------------------------------------------${NC}"
     echo -e "${BLUE}Running tests:"
     echo -e "${BLUE}${CMD}"


### PR DESCRIPTION
## Description:
Added the `--test-only` option to the sip test test runner script to simply run unit tests and ignore linters and code coverage. This greatly speeds up running unit tests locally during development should this script be used.

## Testing instructions:
This option can be tested by running any of the current sub-module unit tests. For example to run all unit tests on the configuration database API with and without linting the following commands can be used.

```bash
./tools/run_tests.sh sip/execution_control/configuration_db 
./tools/run_tests.sh sip/execution_control/configuration_db --test-only
```

## Types of changes
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
