### PR TITLE
Integration of prometheus alarms into SIP demo.

### DIFF
--- a/deploy/demos_23_11_18/docker-compose.yml
+++ b/deploy/demos_23_11_18/docker-compose.yml
@@ -95,6 +95,11 @@ services:
     deploy:
       mode: replicated
       replicas: 1
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:5000/"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
 
   # ==========================================================================
   # Execution Control containers
@@ -109,6 +114,12 @@ services:
     deploy:
       mode: replicated
       replicas: 1
+    healthcheck:
+      test: ["CMD", "ps", "-opid=", "|", "grep", "-e", "'[[:space:]]1$$'",
+             ">/dev/null"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
 
   ec_processing_controller:
     image: skasip/processing_controller:1.2.6

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -1,0 +1,237 @@
+version: '3.6'
+
+services:
+
+  # ==========================================================================
+  # Tango Control containers
+  # ==========================================================================
+
+  tc_tango_master:
+    image: skasip/tango_master:1.2.0
+    environment:
+    - TANGO_HOST=tc_tango_database:10000
+    - REDIS_HOST=ec_config_database
+    deploy:
+      mode: replicated
+      replicas: 1
+    depends_on:
+    - config_database
+    - tango_database
+
+  tc_tango_subarray:
+    image: skasip/tango_subarray:1.2.0
+    environment:
+    - TANGO_HOST=tc_tango_database:10000
+    - REDIS_HOST=ec_config_database
+    deploy:
+      mode: replicated
+      replicas: 1
+    depends_on:
+    - config_database
+    - tango_database
+
+  tc_tango_processing_block:
+    image: skasip/tango_processing_block:1.2.0
+    environment:
+    - TANGO_HOST=tc_tango_database:10000
+    - REDIS_HOST=ec_config_database
+    deploy:
+      mode: replicated
+      replicas: 1
+    depends_on:
+    - config_database
+    - tango_database
+
+  tc_tango_database:
+    image: skasip/tango_database:1.0.4
+    ports:
+    - 10000:10000
+    environment:
+    - MYSQL_HOST=tc_tango_mysql:3306
+    - MYSQL_USER=tango
+    - MYSQL_PASSWORD=tango
+    - MYSQL_DATABASE=tango_db
+    deploy:
+      mode: replicated
+      replicas: 1
+      placement:
+        constraints:
+        - node.role == manager
+    depends_on:
+    - tango_mysql
+
+  tc_tango_mysql:
+    image: skasip/tango_mysql:1.0.3
+    environment:
+    - MYSQL_ROOT_PASSWORD=sip1
+    deploy:
+      mode: replicated
+      replicas: 1
+    volumes:
+    - sip_tango_mysql:/var/lib/mysql:consistent
+
+  tc_flask_master:
+    image: skasip/flask_master:1.2.0
+    ports:
+    - 5000:5000
+    environment:
+    - REDIS_HOST=ec_config_database
+    deploy:
+      mode: replicated
+      replicas: 1
+    depends_on:
+    - config_database
+
+  # ==========================================================================
+  # Execution Control containers
+  # ==========================================================================
+
+  ec_master_controller:
+    image: skasip/master_controller
+    command: ["-v", "--random_errors"]
+    environment:
+    - REDIS_HOST=ec_config_database
+    - REDIS_PORT=6379
+    deploy:
+      mode: replicated
+      replicas: 1
+    depends_on:
+    - config_database
+
+  ec_processing_controller:
+    image: skasip/processing_controller:1.2.0
+    environment:
+    - CELERY_BROKER_URL=redis://ec_celery_broker/1
+    - CELERY_RESULT_BACKEND=redis://ec_celery_backend/2
+    - REDIS_HOST=ec_config_database
+    deploy:
+      mode: replicated
+      replicas: 1
+    depends_on:
+    - config_database
+
+  ec_processing_block_controller:
+    image: skasip/processing_block_controller:1.2.0
+    environment:
+    - CELERY_BROKER_URL=redis://ec_celery_broker/1
+    - CELERY_RESULT_BACKEND=redis://ec_celery_backend/2
+    - REDIS_HOST=ec_config_database
+    volumes:
+    - /var/run/docker.sock:/var/run/docker.sock
+    deploy:
+      mode: replicated
+      replicas: 1
+    depends_on:
+    - config_database
+    - processing_block_controller_broker
+    - processing_block_controller_backend
+
+  ec_config_database:
+    image: redis:5.0.1-alpine
+    deploy:
+      mode: replicated
+      replicas: 1
+    ports:
+    - 6379:6379
+    volumes:
+    - sip_config_database:/data/db
+
+  ec_celery_broker:
+    image: redis:5.0.1-alpine
+    deploy:
+      mode: replicated
+      replicas: 1
+    volumes:
+    - sip_pbc_broker:/data/db
+
+  ec_celery_backend:
+    image: redis:5.0.1-alpine
+    deploy:
+      mode: replicated
+      replicas: 1
+    volumes:
+    - sip_pbc_backend:/data/db
+
+  # ==========================================================================
+  # Platform containers ?
+  # ==========================================================================
+
+  platform_redis-commander-db0:
+    image: rediscommander/redis-commander
+    ports:
+    - 8081:8081
+    environment:
+    - REDIS_HOSTS=config_db:ec_config_database:6379:0
+    deploy:
+      mode: replicated
+      replicas: 1
+    depends_on:
+    - config_database
+
+  # ==========================================================================
+  # Prometheus alarms containers
+  # ==========================================================================
+
+  prometheus:
+    image: skasip/prometheus
+    deploy:
+      mode: replicated
+      replicas: 1
+    ports:
+      - 9090:9090
+
+  pushgateway:
+    image: prom/pushgateway
+    deploy:
+      mode: global
+    ports:
+      - 9091:9091
+
+  alarm_receiver:
+    image: skasip/alarm_receiver
+    deploy:
+      mode: replicated
+      replicas: 1
+    ports:
+      - 9095:9095
+    depends_on:
+      - "kafka"
+
+  alert_manager:
+    image: skasip/alert_manager
+    deploy:
+      mode: replicated
+      replicas: 1
+    ports:
+      - 9093:9093
+
+  zookeeper:
+    image: wurstmeister/zookeeper
+    deploy:
+      mode: replicated
+      replicas: 1
+    ports:
+      - "2181:2181"
+
+  kafka:
+    image: wurstmeister/kafka
+    deploy:
+      mode: replicated
+      replicas: 1
+    ports:
+      - "9094:9094"
+    environment:
+      HOSTNAME_COMMAND: "route -n | awk '/UG[ \t]/{print $$2}'"
+      KAFKA_ADVERTISED_LISTENERS: INSIDE://:9092,OUTSIDE://_{HOSTNAME_COMMAND}:9094
+      KAFKA_LISTENERS: INSIDE://:9092,OUTSIDE://:9094
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: INSIDE:PLAINTEXT,OUTSIDE:PLAINTEXT
+      KAFKA_INTER_BROKER_LISTENER_NAME: INSIDE
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+
+volumes:
+  sip_config_database:
+  sip_pbc_broker:
+  sip_pbc_backend:
+  sip_tango_mysql:

--- a/sip/execution_control/docker_api/sip_docker_swarm/compose-file/docker-compose-env.yml
+++ b/sip/execution_control/docker_api/sip_docker_swarm/compose-file/docker-compose-env.yml
@@ -1,0 +1,20 @@
+version: '3.6'
+
+services:
+
+  process_data:
+    image: skasip/dask_scheduler_base
+    deploy:
+      mode: replicated
+      replicas: 1
+      restart_policy:
+        condition: none
+    environment:
+      - PYTHONPATH=/pipelines:/pipelines/sdp_arl
+      - ARL_DASK_SCHEDULER=dask-stack_scheduler:8786
+    networks:
+      - ical_sip
+
+networks:
+  ical_sip:
+    external: true

--- a/sip/execution_control/docker_api/sip_docker_swarm/docker_swarm_client.py
+++ b/sip/execution_control/docker_api/sip_docker_swarm/docker_swarm_client.py
@@ -421,10 +421,10 @@ class DockerSwarmClient:
         Args:
             service_id (str): docker swarm service id
 
-        Returns,
+        Returns:
             str, replicated level of the service
-        """
 
+        """
         # Raise an exception if we are not a manager
         if not self._manager:
             raise RuntimeError('Only the Swarm manager node can retrieve '
@@ -441,8 +441,9 @@ class DockerSwarmClient:
         Args:
             service_id (str): docker swarm service id
 
-        Returns,
+        Returns:
             str, replication level of the service
+
         """
         # Initialising empty list
         replicas = []
@@ -520,6 +521,9 @@ class DockerSwarmClient:
             if 'logging' in key:
                 self._parse_logging(value, service_config)
                 service_config.pop('logging')
+            if 'environment' in key:
+                service_config['env'] = value
+                service_config.pop('environment')
 
         return service_config
 

--- a/sip/execution_control/docker_api/sip_docker_swarm/tests/test_docker_swarm_client.py
+++ b/sip/execution_control/docker_api/sip_docker_swarm/tests/test_docker_swarm_client.py
@@ -246,7 +246,7 @@ def test_replication_level():
 
 
 def test_actual_replica_level():
-    """Test function for getting the actaul replica level of a service."""
+    """Test function for getting the actual replica level of a service."""
     config_path = os.path.join(FILE_PATH, '..', 'compose-file',
                                'docker-compose-replica.yml')
     with open(config_path, 'r') as compose_str:
@@ -259,3 +259,24 @@ def test_actual_replica_level():
 
     # Cleaning
     DC.delete_service("replica_test")
+
+
+def test_environment():
+    """Test function for setting environment variables."""
+    config_path = os.path.join(FILE_PATH, '..', 'compose-file',
+                               'docker-compose-env.yml')
+    with open(config_path, 'r') as compose_str:
+        s_ids = DC.create_services(compose_str)
+        assert len(s_ids) == 1
+
+    level = 0
+    while level < 1:
+        for service_id in s_ids:
+            level = DC.get_replicas(service_id)
+
+    for s_id in s_ids:
+        replicas = DC.get_replicas(s_id)
+        assert replicas == 1
+
+    # Cleaning
+    DC.delete_service("process_data")

--- a/sip/execution_control/docker_api/sip_docker_swarm/version.py
+++ b/sip/execution_control/docker_api/sip_docker_swarm/version.py
@@ -1,4 +1,4 @@
 # coding=utf-8
 """Package version."""
-__version_info__ = (1, 0, 9)
+__version_info__ = (1, 0, 10)
 __version__ = '.'.join(map(str, __version_info__))

--- a/sip/execution_control/master_controller/Dockerfile
+++ b/sip/execution_control/master_controller/Dockerfile
@@ -11,5 +11,8 @@ WORKDIR /home/sip
 
 COPY app app
 
+HEALTHCHECK --interval=15s --timeout=2s --start-period=5s --retries=2 \
+    CMD ps -opid= | grep -e '[[:space:]]1$' >/dev/null
+
 ENTRYPOINT ["python3", "-m", "app"]
 CMD []

--- a/sip/execution_control/master_controller/requirements.txt
+++ b/sip/execution_control/master_controller/requirements.txt
@@ -1,3 +1,4 @@
 skasip-config-db==1.2.0
 skasip-logging==1.0.14
 skasip-docker-swarm==1.0.7
+prometheus_client

--- a/sip/execution_control/master_controller/requirements.txt
+++ b/sip/execution_control/master_controller/requirements.txt
@@ -1,2 +1,3 @@
 skasip-config-db==1.2.0
 skasip-logging==1.0.14
+skasip-docker-swarm==1.0.7

--- a/sip/execution_control/processing_block_controller/CHANGELOG.md
+++ b/sip/execution_control/processing_block_controller/CHANGELOG.md
@@ -7,6 +7,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to 
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.1] - 2019-01-23
+### Changed
+- Updated to Docker Swarm API 1.0.10.
+
 ## [1.3.0] - 2019-01-09
 ### Changed
 - Updated dockerfile to run the PBC as a root user. While not generally a good

--- a/sip/execution_control/processing_block_controller/requirements.txt
+++ b/sip/execution_control/processing_block_controller/requirements.txt
@@ -1,5 +1,5 @@
 skasip-config-db>=1.2.2
-skasip-docker-swarm>=1.0.7
+skasip-docker-swarm>=1.0.10
 skasip-logging>=1.0.14
 redis==2.10.6
 jinja2==2.10

--- a/sip/execution_control/processing_block_controller/setup.py
+++ b/sip/execution_control/processing_block_controller/setup.py
@@ -18,7 +18,7 @@ setup(name='skasip-pbc',
       packages=['sip_pbc'],
       install_requires=[
           'skasip-config-db>=1.2.2',
-          'skasip-docker-swarm>=1.0.7',
+          'skasip-docker-swarm>=1.0.10',
           'skasip-logging>=1.0.14',
           'redis==2.10.6',
           'jinja2==2.10',

--- a/sip/execution_control/processing_block_controller/sip_pbc/release.py
+++ b/sip/execution_control/processing_block_controller/sip_pbc/release.py
@@ -2,7 +2,7 @@
 """Processing Block Controller release info."""
 __subsystem__ = 'ExecutionControl'
 __service_name__ = 'ProcessingBlockController'
-__version_info__ = (1, 3, 0)
+__version_info__ = (1, 3, 1)
 __version__ = '.'.join(map(str, __version_info__))
 __service_id__ = ':'.join(map(str, (__subsystem__,
                                     __service_name__,

--- a/sip/execution_control/processing_controller/CHANGELOG.md
+++ b/sip/execution_control/processing_controller/CHANGELOG.md
@@ -8,6 +8,9 @@ The format is based on
 and this project adheres to
  [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.7] - 2019-01-23
+### Changed
+- Updated to Docker Swarm API 1.0.10.
 
 ## [1.2.6] - 2019-01-10
 ### Changed

--- a/sip/execution_control/processing_controller/requirements.txt
+++ b/sip/execution_control/processing_controller/requirements.txt
@@ -1,6 +1,6 @@
 skasip-pbc>=1.3.0
 skasip-config-db>=1.2.2
-skasip-docker-swarm>=1.0.7
+skasip-docker-swarm>=1.0.10
 skasip-logging>=1.0.14
 jinja2==2.10
 celery==4.2.1

--- a/sip/execution_control/processing_controller/scheduler/release.py
+++ b/sip/execution_control/processing_controller/scheduler/release.py
@@ -2,7 +2,7 @@
 """Processing Controller release info."""
 __subsystem__ = 'ExecutionControl'
 __service_name__ = 'ProcessingController'
-__version_info__ = (1, 2, 6)
+__version_info__ = (1, 2, 7)
 __version__ = '.'.join(map(str, __version_info__))
 __service_id__ = ':'.join(map(str, (__subsystem__,
                                     __service_name__,

--- a/sip/platform/alarms/README.md
+++ b/sip/platform/alarms/README.md
@@ -1,0 +1,12 @@
+# SIP Alarm Handling
+
+## Description
+
+This package groups all modules related to the generation and management of 
+SDP alarms.
+
+## Implementation Variants
+
+- [**prometheus**] (https://prometheus.io/)
+
+## References

--- a/sip/platform/alarms/prometheus/README.md
+++ b/sip/platform/alarms/prometheus/README.md
@@ -1,0 +1,44 @@
+# SIP Alarm Handling - prometheus implementation
+
+## Description
+
+This package is a demonstration of how prometheus could be used as the
+mechanism for generating SDP alarms.
+
+It consists of the following components (all deployable as docker containers)
+
+- A "push gateway" that receives metrics from applications and makes them
+  available to be "scraped" by prometheus.
+
+- prometheus. This gathers metrics from the push gateways and generates
+  alerts on the basis of simple rules. The demo is configured to generate
+  an alert whenever "demo_alarm" has the value 1.
+
+- An alert manager that receives alerts from prometheus and applies rules
+  (which can involve multiple alerts) to generate alarms and route them
+  to alarm receivers. The demo simple generates an alarm whenever the
+  demo_alarm alert is received and sends it to the alarm receiver with
+  an http POST.
+
+- An alarm receiver which is a WebHook application that writes the alarm 
+  (as a JSON string) into a Kafka queue. The topic name is SIP-alarms.
+
+The Kafka broker listens to port 9094 on the host that started the
+containers. Alarms can be viewed with the kafka command line client
+```
+kafkacat -b 127.0.0.1:9094 -C -t SIP-alarms
+```
+Note that it can take up 30 seconds after the SIP state has been set to "alarm" 
+for an alarm to appear and up to 5 minutes for an alarm to be resolved when
+the SIP state is no longer "alarm".
+
+## Python client
+
+To listen for alarms from Python
+
+```python
+from kafka import KafkaConsumer
+consumer = KafkaConsumer('SIP-alarms',bootstrap_servers='localhost:9094')
+for msg in consumer:
+    print(msg)
+```

--- a/sip/platform/alarms/prometheus/alarm_receiver/Dockerfile
+++ b/sip/platform/alarms/prometheus/alarm_receiver/Dockerfile
@@ -1,0 +1,8 @@
+FROM python:3.6-alpine3.6
+WORKDIR /app
+COPY requirements.txt .
+RUN apk update && \
+    pip install --no-cache-dir -r requirements.txt
+COPY app app
+ENV REDIS_HOST redis
+ENTRYPOINT ["gunicorn", "-b", "0.0.0.0:9095", "app.app:APP"]

--- a/sip/platform/alarms/prometheus/alarm_receiver/README.md
+++ b/sip/platform/alarms/prometheus/alarm_receiver/README.md
@@ -1,0 +1,5 @@
+# SIP Prometheus Alarm Receiver Service
+
+The alarm receiver is a WebHook application which listens for htlm PUTs from
+Prometheus and inserts the JSON describing an alert into a Kafka queue. The
+Kafka topic is "SIP-alarms".

--- a/sip/platform/alarms/prometheus/alarm_receiver/app/__init__.py
+++ b/sip/platform/alarms/prometheus/alarm_receiver/app/__init__.py
@@ -1,11 +1,10 @@
 # coding=utf-8
-"""SIP Execution Control Master Controller."""
-__subsystem__ = 'ExecutionControl'
-__service_name__ = 'MasterController'
-__version_info__ = (1, 2, 0)
+"""SIP Prometheus Alarm Receiver."""
+__subsystem__ = 'Platform.Alarms.Prometheus'
+__service_name__ = 'AlarmReceiver'
+__version_info__ = (1, 0, 0)
 __version__ = '.'.join(map(str, __version_info__))
 __service_id__ = ':'.join(map(str, (__subsystem__,
                                     __service_name__,
                                     __version__)))
-import logging
-LOG = logging.getLogger('sip.ec.master_controller')
+

--- a/sip/platform/alarms/prometheus/alarm_receiver/app/app.py
+++ b/sip/platform/alarms/prometheus/alarm_receiver/app/app.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+"""Demo alarm hander."""
+
+import logging
+import time
+import json
+from flask import request
+from flask_api import FlaskAPI
+from kafka import KafkaProducer
+
+APP = FlaskAPI(__name__)
+
+logging.basicConfig(level=logging.INFO)
+
+# This sleep is needed to give kafka time to start up.
+time.sleep(2)
+producer = KafkaProducer(bootstrap_servers='kafka:9092')
+
+@APP.route('/')
+def root():
+    """."""
+    return {
+        "message": "The demo alarm handler says hi",
+        "_links": {
+            "items": [
+                {"href": "{}".format(request.url)}
+            ]
+        }
+    }
+
+
+@APP.route('/', methods=['POST'])
+def alarm():
+    """."""
+    if request.method == 'POST':
+        response = {'message': 'POST Accepted'}
+        logging.info('alarm POSTED!')
+        data = request.data
+        logging.info(data)
+        string = json.dumps(data)
+        producer.send('SIP-alarms', string.encode())
+        return response
+    return ""

--- a/sip/platform/alarms/prometheus/alarm_receiver/build_image.sh
+++ b/sip/platform/alarms/prometheus/alarm_receiver/build_image.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# Script to build and upload a docker image.
+
+function build_and_publish_image() {
+    RED='\033[0;31m'
+    BLUE='\033[0;34m'
+    NC='\033[0m'
+    VERSION="$(python -c "import app; print(app.__version__)")"
+    IMAGE=skasip/alarm_receiver
+    echo -e "${RED}--------------------------------------------------------------${NC}"
+    echo -e "${BLUE}Building and uploading ${IMAGE} image, version = latest, ${VERSION}"
+    echo -e "${RED}--------------------------------------------------------------${NC}"
+    docker build -t ${IMAGE}:latest .
+    docker tag ${IMAGE}:latest ${IMAGE}:"${VERSION}"
+    docker push ${IMAGE}:latest
+    docker push ${IMAGE}:"${VERSION}"
+}
+
+build_and_publish_image

--- a/sip/platform/alarms/prometheus/alarm_receiver/requirements.txt
+++ b/sip/platform/alarms/prometheus/alarm_receiver/requirements.txt
@@ -1,0 +1,4 @@
+flask
+flask_api
+gunicorn
+kafka>=1.0

--- a/sip/platform/alarms/prometheus/alert_manager/Dockerfile
+++ b/sip/platform/alarms/prometheus/alert_manager/Dockerfile
@@ -1,0 +1,3 @@
+FROM prom/alertmanager
+ADD alerts.yml /etc/
+CMD ["--config.file=/etc/alerts.yml", "--storage.path=/alertmanager"]

--- a/sip/platform/alarms/prometheus/alert_manager/README.md
+++ b/sip/platform/alarms/prometheus/alert_manager/README.md
@@ -1,0 +1,5 @@
+# SIP Prometheus alert manager
+
+The Prometheus alert manager configured to forward alarms to the SIP
+alarm receiver WebHook server.
+

--- a/sip/platform/alarms/prometheus/alert_manager/alerts.yml
+++ b/sip/platform/alarms/prometheus/alert_manager/alerts.yml
@@ -1,0 +1,10 @@
+global:
+  resolve_timeout: 30s
+
+route:
+  receiver: 'sip'
+
+receivers:
+  - name: 'sip'
+    webhook_configs:
+       - url: 'http://alarm_receiver:9095/'

--- a/sip/platform/alarms/prometheus/alert_manager/build_image.sh
+++ b/sip/platform/alarms/prometheus/alert_manager/build_image.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# Script to build and upload a docker image.
+
+function build_and_publish_image() {
+    RED='\033[0;31m'
+    BLUE='\033[0;34m'
+    NC='\033[0m'
+    VERSION="1.0.0"
+    #VERSION="$(python -c "import app; print(app.__version__)")"
+    IMAGE=skasip/alert_manager
+    echo -e "${RED}--------------------------------------------------------------${NC}"
+    echo -e "${BLUE}Building and uploading ${IMAGE} image, version = latest, ${VERSION}"
+    echo -e "${RED}--------------------------------------------------------------${NC}"
+    docker build -t ${IMAGE}:latest .
+    docker tag ${IMAGE}:latest ${IMAGE}:"${VERSION}"
+    docker push ${IMAGE}:latest
+    docker push ${IMAGE}:"${VERSION}"
+}
+
+build_and_publish_image

--- a/sip/platform/alarms/prometheus/prometheus/Dockerfile
+++ b/sip/platform/alarms/prometheus/prometheus/Dockerfile
@@ -1,0 +1,3 @@
+FROM prom/prometheus
+ADD prometheus.yml /etc/prometheus/
+ADD alert_rules.yml /etc/prometheus/

--- a/sip/platform/alarms/prometheus/prometheus/README.md
+++ b/sip/platform/alarms/prometheus/prometheus/README.md
@@ -1,0 +1,9 @@
+# SIP Prometheus 
+
+Prometheus configured to receive alerts from all the push push gateways
+in a Docker swarm.
+
+It has just one alert rule; to raise an alert called "SipStateAlarm" if
+the metric "sip\_state" has the value "1".
+
+Additional alerts are added by editing alert\_rules.yml

--- a/sip/platform/alarms/prometheus/prometheus/alert_rules.yml
+++ b/sip/platform/alarms/prometheus/prometheus/alert_rules.yml
@@ -1,0 +1,6 @@
+groups:
+- name: sip
+  interval: 5s
+  rules:
+  - alert: SipStateAlarm
+    expr: sip_state == 1

--- a/sip/platform/alarms/prometheus/prometheus/build_image.sh
+++ b/sip/platform/alarms/prometheus/prometheus/build_image.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# Script to build and upload a docker image.
+
+function build_and_publish_image() {
+    RED='\033[0;31m'
+    BLUE='\033[0;34m'
+    NC='\033[0m'
+    VERSION="1.0.0"
+    #VERSION="$(python -c "import app; print(app.__version__)")"
+    IMAGE=skasip/prometheus
+    echo -e "${RED}--------------------------------------------------------------${NC}"
+    echo -e "${BLUE}Building and uploading ${IMAGE} image, version = latest, ${VERSION}"
+    echo -e "${RED}--------------------------------------------------------------${NC}"
+    docker build -t ${IMAGE}:latest .
+    docker tag ${IMAGE}:latest ${IMAGE}:"${VERSION}"
+    docker push ${IMAGE}:latest
+    docker push ${IMAGE}:"${VERSION}"
+}
+
+build_and_publish_image

--- a/sip/platform/alarms/prometheus/prometheus/prometheus.yml
+++ b/sip/platform/alarms/prometheus/prometheus/prometheus.yml
@@ -1,0 +1,37 @@
+global:
+  scrape_interval:     15s # By default, scrape targets every 15 seconds.
+
+  # Attach these labels to any time series or alerts when communicating with
+  # external systems (federation, remote storage, Alertmanager).
+  external_labels:
+    monitor: 'codelab-monitor'
+
+rule_files:
+  - /etc/prometheus/alert_rules.yml
+
+# A scrape configuration containing exactly one endpoint to scrape:
+scrape_configs:
+  # The job name is added as a label `job=<job_name>` to any timeseries scraped from this config.
+  - job_name: 'pushgateway'
+
+    honor_labels: true
+
+    # Override the global default and scrape targets from this job every 5 seconds.
+    scrape_interval: 5s
+
+    #static_configs:
+    #  - targets: ['pushgateway:9091']
+
+    dns_sd_configs:
+      - names:
+        - 'tasks.pushgateway'
+        type: 'A'
+        port: 9091
+
+alerting:
+  alertmanagers:
+    - scheme: http
+      static_configs:
+      - targets: 
+        - "alert_manager:9093"
+


### PR DESCRIPTION
## Description:
Integration of Prometheus alarms demo into SIP. 

To achieve this a set of additional services providing a Prometheus alarms backend are started and the EC Master Controller has been updated to set the value of an SDP state alarm (Prometheus) Gauge whenever the SDP state is in the 'alarm' state.

For more details see `sip/platform/alarms/prometheus/README.md`.

- A new `docker-compose.yml` demo file as been added to the `deploy/` folder. 
  This starts:
  - A Prometheus container
  - Globally replicated push gateway containers
  - An alarm receiver container
  - An alert manager instance container
  - zookeeper and kafka containers
- The following platform modules have been added:
   - `sip/platform/alarms/prometheus/alarm_receiver`: Application which listens to HTML PUT requests from Prometheus and inserts the JSON describing the alert into a Kafka queue with topic `'SIP-alarms'`.
   - `sip/platform/alarms/prometheus/alert_manager`: Prometheus alert manager configure to forward alarms to the SIP alarm receiver (see above)
   - `sip/platform/alarms/prometheus`: Prometheus configuration files for receiving alerts from all push gateways. Currently configured with a single alert rule which raises an alert called `SipStateAlarm` if the metric `sip_state` has value 1 .

This completes [[TSK-2707](https://jira.ska-sdp.org/browse/TSK-2707)]

## Testing instructions:
See `sip/platform/alarms/prometheus/README.md`

## Types of changes
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
