### PR TITLE
TSK-2727 Initial Tango Log aggregator

### DIFF
--- a/sip/tango_control/tango_logger/Dockerfile
+++ b/sip/tango_control/tango_logger/Dockerfile
@@ -1,0 +1,14 @@
+FROM skasip/tango_docker_base:1.1.3
+LABEL maintainer="Brian McIlwrath <brian.mcilwrath@stfc.ac.uk>"
+
+USER root
+
+COPY requirements.txt .
+RUN pip3 install -r requirements.txt
+
+USER sip
+
+COPY app app
+
+ENTRYPOINT ["./app/sdp_logger_ds.py"]
+CMD ["1", "-v4"]

--- a/sip/tango_control/tango_logger/README.md
+++ b/sip/tango_control/tango_logger/README.md
@@ -1,0 +1,3 @@
+# SIP SDP Tango Logger (SDP Element Logger)
+
+See description in the SIP report for more details on this service.

--- a/sip/tango_control/tango_logger/README.md
+++ b/sip/tango_control/tango_logger/README.md
@@ -2,4 +2,29 @@
 
 See description in the SIP report for more details on this service.
 
-Read
+The SDP logger SHOULD be a log aggregator for ALL SDP Tango Devuice Servers. The  file 'tango_logging_notes.txt'
+explains some problems in getting this to work as we would wish - and the Tango authors may need to be consoluted!
+
+A descoped JIRA ticket (TSK-2727) was created which defines recipt of logging messages from the SDP Tango Master
+Device
+
+To test this
+
+Bring up the 'sip' Docker stack from the file 'tango_logger/docker_compose.yml'
+
+Send the tango_master any command (eg. 'status')
+
+d=DeviceProxy('sip_sdp/elt/master')
+d.status()
+
+From a terminal window obtain docker logs of 'logger process'
+
+docker ps |grep logger -> capture ID
+docker logs <id>
+
+
+Should obtain
+
+2019-02-26 15:38:36,607 - sip.tc.sdp_logger - INFO - sdp_logger_device.py:56 |
+TANGO Log message - 2019-02-26 15:38:36 - INFO sip_sdp/elt/master Test of Tango logging from 'tc_tango_master'
+

--- a/sip/tango_control/tango_logger/README.md
+++ b/sip/tango_control/tango_logger/README.md
@@ -1,3 +1,5 @@
 # SIP SDP Tango Logger (SDP Element Logger)
 
 See description in the SIP report for more details on this service.
+
+Read

--- a/sip/tango_control/tango_logger/app/__init__.py
+++ b/sip/tango_control/tango_logger/app/__init__.py
@@ -1,0 +1,2 @@
+# coding=utf-8
+"""Tango SDP Logger."""

--- a/sip/tango_control/tango_logger/app/release.py
+++ b/sip/tango_control/tango_logger/app/release.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+"""SIP Tango Logger Device package."""
+import logging
+__subsystem__ = 'TangoControl'
+__service_name__ = 'SDPLogger'
+__version_info__ = (1, 1, 0)
+__version__ = '.'.join(map(str, __version_info__))
+__service_id__ = ':'.join(map(str, (__subsystem__,
+                                    __service_name__,
+                                    __version__)))
+LOG = logging.getLogger('sip.tc.sdp_logger')
+__all__ = [
+    '__subsystem__',
+    '__service_name__',
+    '__version__',
+    '__service_id__',
+    'LOG'
+]

--- a/sip/tango_control/tango_logger/app/sdp_logger_device.py
+++ b/sip/tango_control/tango_logger/app/sdp_logger_device.py
@@ -1,0 +1,60 @@
+# -*- coding: utf-8 -*-
+"""Tango Logger device class."""
+
+import json
+import time
+
+import jsonschema
+import datetime
+
+from tango import DebugIt, DevState, DeviceProxy
+
+from tango.server import Device, attribute, class_property, command, pipe
+from release import LOG, __service_name__, __subsystem__, __version__
+
+class SDPLoggerDevice(Device):
+    """SDP Logger device class."""
+
+    _start_time = time.time()
+
+    # -------------------------------------------------------------------------
+    # General methods
+    # -------------------------------------------------------------------------
+
+    def init_device(self):
+        """Initialise the device."""
+        Device.init_device(self)
+
+        SDP_Devices = ["sdp/elt/master", ] # Plus ALL PDB and Subarray devices!!!
+
+        for dev in SDP_Devices:
+            d = DeviceProxy(dev)
+            d.add_logging_target("device::sdp/elt/logger")
+            LOG.info("Logging targets %s", d.get_logging_targets())
+
+    # version = class_property(dtype=str, default_value='test')
+
+    # ---------------
+    # Commands
+    # ---------------
+    @command(dtype_in=(str,), dtype_out=None)
+    @DebugIt()
+    def log(self, argin):
+        """Log a command for the SDP STango ubsystem devices."""
+      # Tango Manual Appendix 9 gives the format
+        # argin[0] = millisecond Unix timestamp
+        # argin[1] = log level
+        # argin[2] = the source log device name
+        # argin[3] = the log message
+        # argin[4] = Not used - reserved
+        # argin[5] = thread identifier of originating message
+
+        t = datetime.datetime.fromtimestamp(float(argin[0])/1000.)
+        fmt = "%Y-%m-%d %H:%M:%S"
+        message = "TANGO Log message - {} - {} {} {}".format(t.strftime(fmt),argin[1],
+             argin[2], argin[3])
+        LOG.info(message)
+
+
+
+   

--- a/sip/tango_control/tango_logger/app/sdp_logger_device.py
+++ b/sip/tango_control/tango_logger/app/sdp_logger_device.py
@@ -4,10 +4,10 @@
 import time
 import datetime
 
-from tango import DebugIt, DevState, DeviceProxy
+from tango import DebugIt
+from tango.server import Device, attribute, class_property, command
+from release import LOG, __version__
 
-from tango.server import Device, attribute, class_property, command, pipe
-from release import LOG, __service_name__, __subsystem__, __version__
 
 class SDPLoggerDevice(Device):
     """SDP Logger device class."""
@@ -22,23 +22,26 @@ class SDPLoggerDevice(Device):
         """Initialise the device."""
         Device.init_device(self)
 
-        SDP_Devices = ["sip_sdp/elt/master", ] # Plus ALL PDB and Subarray devices!!!
+    SDP_Devices = ["sip_sdp/elt/master", ]  # (ToDo(BMc) - all DSs)
+    #
+    #   for dev in SDP_Devices:
+    #      d = DeviceProxy(dev)
+    #      d.add_logging_target("device::sip_sdp/elt/logger")
+    #      LOG.debug("%s device logging targets %s", dev,
+    #                 d.get_logging_targets())
 
-      #for dev in SDP_Devices:
-      #      d = DeviceProxy(dev)
-      #      d.add_logging_target("device::sip_sdp/elt/logger")
-      #      LOG.debug("%s device logging targets %s", dev, d.get_logging_targets())
-
-    #version = class_property(dtype=str, default_value='test')
+    # version = class_property(dtype=str, default_value='test')
 
     # ---------------
     # Commands
     # ---------------
+
     @command(dtype_in=(str,), dtype_out=None)
     @DebugIt()
     def log(self, argin):
         """Log a command for the SDP STango ubsystem devices."""
-      # Tango Manual Appendix 9 gives the format
+        #
+        # Tango Manual Appendix 9 gives the format
         # argin[0] = millisecond Unix timestamp
         # argin[1] = log level
         # argin[2] = the source log device name
@@ -46,12 +49,11 @@ class SDPLoggerDevice(Device):
         # argin[4] = Not used - reserved
         # argin[5] = thread identifier of originating message
 
-        t = datetime.datetime.fromtimestamp(float(argin[0])/1000.)
+        tm = datetime.datetime.fromtimestamp(float(argin[0])/1000.)
         fmt = "%Y-%m-%d %H:%M:%S"
-        message = "TANGO Log message - {} - {} {} {}".format(t.strftime(fmt),argin[1],
-             argin[2], argin[3])
+        message = "TANGO Log message - {} - {} {} {}".format(
+            tm.strftime(fmt), argin[1], argin[2], argin[3])
         LOG.info(message)
-
 
     # ------------------
     # Attributes methods
@@ -61,4 +63,3 @@ class SDPLoggerDevice(Device):
     def version(self):
         """Return the version of the Master Controller Device."""
         return __version__
-   

--- a/sip/tango_control/tango_logger/app/sdp_logger_device.py
+++ b/sip/tango_control/tango_logger/app/sdp_logger_device.py
@@ -1,10 +1,7 @@
 # -*- coding: utf-8 -*-
 """Tango Logger device class."""
 
-import json
 import time
-
-import jsonschema
 import datetime
 
 from tango import DebugIt, DevState, DeviceProxy
@@ -25,14 +22,14 @@ class SDPLoggerDevice(Device):
         """Initialise the device."""
         Device.init_device(self)
 
-        SDP_Devices = ["sdp/elt/master", ] # Plus ALL PDB and Subarray devices!!!
+        SDP_Devices = ["sip_sdp/elt/master", ] # Plus ALL PDB and Subarray devices!!!
 
-        for dev in SDP_Devices:
-            d = DeviceProxy(dev)
-            d.add_logging_target("device::sdp/elt/logger")
-            LOG.info("Logging targets %s", d.get_logging_targets())
+      #for dev in SDP_Devices:
+      #      d = DeviceProxy(dev)
+      #      d.add_logging_target("device::sip_sdp/elt/logger")
+      #      LOG.debug("%s device logging targets %s", dev, d.get_logging_targets())
 
-    # version = class_property(dtype=str, default_value='test')
+    #version = class_property(dtype=str, default_value='test')
 
     # ---------------
     # Commands
@@ -56,5 +53,12 @@ class SDPLoggerDevice(Device):
         LOG.info(message)
 
 
+    # ------------------
+    # Attributes methods
+    # ------------------
 
+    @attribute(dtype=str)
+    def version(self):
+        """Return the version of the Master Controller Device."""
+        return __version__
    

--- a/sip/tango_control/tango_logger/app/sdp_logger_ds.py
+++ b/sip/tango_control/tango_logger/app/sdp_logger_ds.py
@@ -13,8 +13,9 @@ import sys
 from tango import Database, DbDevInfo
 from tango.server import run
 
-from sdp_logger_device import SDPLoggerDevice
 from sip_logging import init_logger
+from sdp_logger_device import SDPLoggerDevice
+
 from release import LOG, __service_id__
 
 
@@ -39,7 +40,9 @@ def main(args=None, **kwargs):
     return run([SDPLoggerDevice], verbose=True, args=args,
                msg_stream=sys.stdout, **kwargs)
 
+
 if __name__ == '__main__':
+
     init_logger(logger_name='', show_log_origin=True)
     init_logger(show_log_origin=True)
     register_logger()

--- a/sip/tango_control/tango_logger/app/sdp_logger_ds.py
+++ b/sip/tango_control/tango_logger/app/sdp_logger_ds.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""SIP SDP Tango Logger Device server.
+
+Run with:
+
+```bash
+python3 sdp_logger_ds.py 1 -v4
+```
+"""
+import sys
+
+from tango import Database, DbDevInfo
+from tango.server import run
+
+from sdp_logger_device import SDPLoggerDevice
+from sip_logging import init_logger
+from release import LOG, __service_id__
+
+
+def register_logger():
+    """Register the SDP Logger device."""
+    tango_db = Database()
+    device = "sip_sdp/elt/logger"
+    device_info = DbDevInfo()
+    device_info._class = "SDPLoggerDevice"
+    device_info.server = "sdp_logger_ds/1"
+    device_info.name = device
+    devices = tango_db.get_device_name(device_info.server, device_info._class)
+    if device not in devices:
+        LOG.info('Registering device "%s" with device server "%s"',
+                 device_info.name, device_info.server)
+        tango_db.add_device(device_info)
+
+
+def main(args=None, **kwargs):
+    """Run the Tango SDP Logger device server."""
+    LOG.info('Starting %s', __service_id__)
+    return run([SDPLoggerDevice], verbose=True, args=args,
+               msg_stream=sys.stdout, **kwargs)
+
+if __name__ == '__main__':
+    init_logger(logger_name='', show_log_origin=True)
+    init_logger(show_log_origin=True)
+    register_logger()
+    main()

--- a/sip/tango_control/tango_logger/build_image.sh
+++ b/sip/tango_control/tango_logger/build_image.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+RED='\033[0;31m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+VERSION="$(python -c "from app.release import __version__; print(__version__)")"
+
+IMAGE=skasip/tango_logger
+echo -e "${RED}--------------------------------------------------------------${NC}"
+echo -e "${BLUE}Building and uploading ${IMAGE} image, version = latest, ${VERSION}"
+echo -e "${RED}--------------------------------------------------------------${NC}"
+
+docker build -t ${IMAGE}:latest .
+docker tag ${IMAGE}:latest ${IMAGE}:${VERSION}
+docker push ${IMAGE}:latest
+docker push ${IMAGE}:${VERSION}

--- a/sip/tango_control/tango_logger/docker-compose.yml
+++ b/sip/tango_control/tango_logger/docker-compose.yml
@@ -1,0 +1,176 @@
+version: '3.6'
+
+services:
+
+  # ==========================================================================
+  # Tango Control containers
+  # ==========================================================================
+
+  tc_tango_logger
+    image: skasip/tango_logger:1.1.0
+    environment:
+    - TANGO_HOST=tc_tango_database:10000
+    deploy:
+      mode: replicated
+      replicas: 1
+    healthcheck:
+      test: ["CMD", "python3", "-c",
+            "import PyTango; d=PyTango.DeviceProxy('sip_sdp/elt/logger');
+            d.ping()"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+
+  tc_tango_master:
+    image: skasip/tango_master:1.2.0
+    environment:
+    - TANGO_HOST=tc_tango_database:10000
+    - REDIS_HOST=ec_config_database
+    deploy:
+      mode: replicated
+      replicas: 1
+    healthcheck:
+      test: ["CMD", "python3", "-c",
+            "import PyTango; d=PyTango.DeviceProxy('sip_sdp/elt/master');
+            d.ping()"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+
+  tc_tango_subarray:
+    image: skasip/tango_subarray:1.2.0
+    environment:
+    - TANGO_HOST=tc_tango_database:10000
+    - REDIS_HOST=ec_config_database
+    deploy:
+      mode: replicated
+      replicas: 1
+    healthcheck:
+      test: ["CMD", "python3", "-c",
+            "import PyTango; d=PyTango.DeviceProxy('sip_sdp/elt/subarray_00');
+            d.ping()"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+
+  tc_tango_processing_block:
+    image: skasip/tango_processing_block:1.2.0
+    environment:
+    - TANGO_HOST=tc_tango_database:10000
+    - REDIS_HOST=ec_config_database
+    deploy:
+      mode: replicated
+      replicas: 1
+    healthcheck:
+      test: ["CMD", "python3", "-c",
+             "import PyTango; d=PyTango.DeviceProxy('sip_sdp/pb/00000');
+             d.ping()"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+
+  tc_tango_database:
+    image: skasip/tango_database:1.0.4
+    ports:
+    - 10000:10000
+    environment:
+    - MYSQL_HOST=tc_tango_mysql:3306
+    - MYSQL_USER=tango
+    - MYSQL_PASSWORD=tango
+    - MYSQL_DATABASE=tango_db
+    deploy:
+      mode: replicated
+      replicas: 1
+      placement:
+        constraints:
+        - node.role == manager
+
+  tc_tango_mysql:
+    image: skasip/tango_mysql:1.0.3
+    environment:
+    - MYSQL_ROOT_PASSWORD=sip1
+    deploy:
+      mode: replicated
+      replicas: 1
+    healthcheck:
+      test: ["CMD", "mysql", "--user=tango", "--password=tango",
+             "-e", "SHOW DATABASES LIKE 'tango_db';"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+    volumes:
+    - sip_tango_mysql:/var/lib/mysql:consistent
+
+  tc_flask_master:
+    image: skasip/flask_master:1.2.0
+    ports:
+    - 5000:5000
+    environment:
+    - REDIS_HOST=ec_config_database
+    deploy:
+      mode: replicated
+      replicas: 1
+
+  # ==========================================================================
+  # Execution Control containers
+  # ==========================================================================
+
+  ec_master_controller:
+    image: skasip/master_controller:1.2.1
+    command: ["-v"]
+    environment:
+    - REDIS_HOST=ec_config_database
+    - REDIS_PORT=6379
+    deploy:
+      mode: replicated
+      replicas: 1
+
+  ec_processing_controller:
+    image: skasip/processing_controller:1.2.6
+    environment:
+    - CELERY_BROKER_URL=redis://ec_config_database/1
+    - CELERY_RESULT_BACKEND=redis://ec_config_database/2
+    - REDIS_HOST=ec_config_database
+    deploy:
+      mode: replicated
+      replicas: 1
+
+  ec_processing_block_controller:
+    image: skasip/processing_block_controller:1.3.0
+    environment:
+    - CELERY_BROKER_URL=redis://ec_config_database/1
+    - CELERY_RESULT_BACKEND=redis://ec_config_database/2
+    - REDIS_HOST=ec_config_database
+    volumes:
+    - /var/run/docker.sock:/var/run/docker.sock
+    deploy:
+      mode: replicated
+      replicas: 1
+
+  ec_config_database:
+    image: redis:5.0.1-alpine
+    deploy:
+      mode: replicated
+      replicas: 1
+    ports:
+    - 6379:6379
+    volumes:
+    - sip_config_database:/data/db
+
+  # ==========================================================================
+  # Platform containers
+  # ==========================================================================
+
+  platform_redis-commander-db0:
+    image: rediscommander/redis-commander
+    ports:
+    - 8081:8081
+    environment:
+    - REDIS_HOSTS=config_db:ec_config_database:6379:0
+    deploy:
+      mode: replicated
+      replicas: 1
+
+volumes:
+  sip_config_database:
+  sip_tango_mysql:

--- a/sip/tango_control/tango_logger/docker-compose.yml
+++ b/sip/tango_control/tango_logger/docker-compose.yml
@@ -6,7 +6,7 @@ services:
   # Tango Control containers
   # ==========================================================================
 
-  tc_tango_logger
+  tc_tango_logger:
     image: skasip/tango_logger:1.1.0
     environment:
     - TANGO_HOST=tc_tango_database:10000
@@ -22,7 +22,7 @@ services:
       retries: 5
 
   tc_tango_master:
-    image: skasip/tango_master:1.2.0
+    image: skasip/tango_master:1.2.1
     environment:
     - TANGO_HOST=tc_tango_database:10000
     - REDIS_HOST=ec_config_database

--- a/sip/tango_control/tango_logger/requirements.txt
+++ b/sip/tango_control/tango_logger/requirements.txt
@@ -1,0 +1,1 @@
+skasip-logging==1.0.14

--- a/sip/tango_control/tango_logger/tango_logging_notes.txt
+++ b/sip/tango_control/tango_logger/tango_logging_notes.txt
@@ -1,0 +1,59 @@
+Last edit: Brian Mcilwrath 21202/2019
+
+This explains most of what I know of Tango device "log aggregators"!
+
+1) Tango device logging is performed by commands such as
+   self.debug_stream('This is an info message')
+   or
+   print("Another debug level message", file=self.debug_info)
+
+   and similar for info, warn, error and fatal messages.
+
+   There are also optional decorators that place automatic log messages o enetering and leaving a Python
+   method implementing a Device Server command or attribute
+
+    eg.
+    @PyTango_DebugIt
+    def aDSCommand(self):
+
+2) There are three possible "logging targets" (appenders)
+
+      Console    ("console::cout")
+      File       ("file::<filename>")
+      Log Device ("device::sip_sdp/elt/logger")
+
+3) The "Log device" target is a Device which implements a Tango command named 'log' - see tago_logger code for
+   arguments provided to this command.
+
+4) There is one logging level for each Device Server (which applies to ALL logging targets for that DS). Only messages
+equal to or more sever than this log levelk are output.
+
+SNAGs - perhaps discuss on ESRF Tango Bulletin Board - if this work neds to be progressed
+
+Logging targets and level seem to be designed to be used via DeviceProxy() -
+
+eg.
+d=DeviceProxy('sip_sdp/elt/master')
+d.set_logging_target('device::sip_sdp/elt/logger')
+print(d.get_logging_targets())
+print(d.get_logging_level')
+
+BUT they must actually be IMPLEMENTED by code in the Device Server code itself!
+
+For SDP purposes it would be ideal if all of our devices (master, processing block and subarray) could
+connect to the logger device automatically - by calling appropriate Device Server commands.
+
+I invisiged something this like
+
+class MyDeviceServer(Device):
+
+   def init_device(self):
+   # Call server command DIRECTLY to setup logging stream to 'device::sip_sdp/elt/logger'
+
+BUT I have failed to discover how to do this!!!!! See the example Tango master DS code which uses something of a hack
+(a loopback DeviceProxy to the Master Device - to do this)
+
+Note also that the standard Tango method 'init_device()' seems to be used too early in the life-cycle to use the
+DeviceProxy for communication
+
+

--- a/sip/tango_control/tango_logger/tango_logging_notes.txt
+++ b/sip/tango_control/tango_logger/tango_logging_notes.txt
@@ -22,7 +22,7 @@ This explains most of what I know of Tango device "log aggregators"!
       File       ("file::<filename>")
       Log Device ("device::sip_sdp/elt/logger")
 
-3) The "Log device" target is a Device which implements a Tango command named 'log' - see tago_logger code for
+3) The "Log device" target is a Device which implements a Tango command named 'log' - see tango_logger code for
    arguments provided to this command.
 
 4) There is one logging level for each Device Server (which applies to ALL logging targets for that DS). Only messages

--- a/sip/tango_control/tango_master/app/release.py
+++ b/sip/tango_control/tango_master/app/release.py
@@ -3,7 +3,7 @@
 import logging
 __subsystem__ = 'TangoControl'
 __service_name__ = 'SDPMaster'
-__version_info__ = (1, 2, 0)
+__version_info__ = (1, 2, 1)
 __version__ = '.'.join(map(str, __version_info__))
 __service_id__ = ':'.join(map(str, (__subsystem__,
                                     __service_name__,

--- a/sip/tango_control/tango_master/app/sdp_master_device.py
+++ b/sip/tango_control/tango_master/app/sdp_master_device.py
@@ -47,10 +47,11 @@ class SDPMasterDevice(Device):
     def always_executed_hook(self):
         """Run for each command."""
         _logT = self._devProxy.get_logging_target()
-        if not 'device::sip_sdp_logger' in _logT:
+        if 'device::sip_sdp_logger' not in _logT:
             try:
                 self._devProxy.add_logging_target('device::sip_sdp/elt/logger')
-                self.info_stream("Test of Tango logging from 'tc_tango_master'")
+                self.info_stream("Test of Tango logging from "
+                                 "'tc_tango_master'")
 
             except Exception as e:
                 LOG.debug('Failed to setup Tango logging %s', e )

--- a/sip/tango_control/tango_master/app/sdp_master_device.py
+++ b/sip/tango_control/tango_master/app/sdp_master_device.py
@@ -27,6 +27,7 @@ class SDPMasterDevice(Device):
     _service_state = ServiceState(__subsystem__, __service_name__,
                                   __version__)
     _sdp_state = SDPState()
+    _devProxy = None
 
     # -------------------------------------------------------------------------
     # General methods
@@ -34,16 +35,24 @@ class SDPMasterDevice(Device):
     def init_device(self):
         """Device constructor."""
         Device.init_device(self)
-        self._set_master_state('init')
 
         # Add anything here that has to be done before the device is set to
         # its ON state.
 
         self._set_master_state('on')
+        self._devProxy = DeviceProxy(self.get_name())
+        #
+        # Trying to add logging target in 'init_device' fails (BKMc)
 
     def always_executed_hook(self):
         """Run for each command."""
-        pass
+        _logT = self._devProxy.get_logging_target()
+        if not 'device::sip_sdp_logger' in _logT:
+            try:
+                self._devProxy.add_logging_target('device::sip_sdp_logger')
+
+            except Exception as e:
+                LOG.debug('Failed to setup Tango logging %s', e )
 
     def delete_device(self):
         """Device destructor."""

--- a/sip/tango_control/tango_master/app/sdp_master_device.py
+++ b/sip/tango_control/tango_master/app/sdp_master_device.py
@@ -49,7 +49,8 @@ class SDPMasterDevice(Device):
         _logT = self._devProxy.get_logging_target()
         if not 'device::sip_sdp_logger' in _logT:
             try:
-                self._devProxy.add_logging_target('device::sip_sdp_logger')
+                self._devProxy.add_logging_target('device::sip_sdp/elt/logger')
+                self.info_stream("Test of Tango logging from 'tc_tango_master'")
 
             except Exception as e:
                 LOG.debug('Failed to setup Tango logging %s', e )
@@ -58,7 +59,7 @@ class SDPMasterDevice(Device):
         """Device destructor."""
         pass
 
-    # ---------------
+    # ---------------dockj
     # Commands
     # ---------------
 


### PR DESCRIPTION
## Description:
Provide an initial "Log aggregator" for the SIP Tango Device Servers - using the Master DS as an example

TSK-2727 SIP: Add aggregated Tango log messages from the SIP Tango Master device

## Testing instructions:

From the top level sip repository:

1. Install/update the Tango SIP stack modules:
```bash
docker stack deploy - c sip/tango_control/tango_logger/docker_compose.yml sip
```

2. Bring up an iTango prompt to the current Tango stack
```bash
./deploy/demos_23_11_18/scripts/get_itango_prompt
```

3. Type the following (to the iTango prompt from (2)) to get the status of the Master Device Server
```python
d=DeviceProxy('sip_sdp/elt/master')
d.status()
quit
```

4. examine Docker logs for Logger
```bash
docker service logs $(docker stack services -q --filter name=sip_tc_tango_logger sip)
```

5. Expect a Tango logging message from Tango_master received by Tango logger!!!!

## Types of changes
<!-- What types of changes does this PR introduce? Put an 'x' in all of the boxes that apply. -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!-- Go over all of the following points and put and 'x' in the boxes that apply. -->
- [ ] The code follows the code style of this project.
- [ ] The changes require a documentation update.
- [ ] Documentation has been updated accordingly.
- [ ] Tests cover all changes in this PR.
- [ ] All new and existing tests passed.
